### PR TITLE
Add a sustainable local install path (revoked-cert guard, iCloud signing race, launchd FDA)

### DIFF
--- a/script/create_local_identity.sh
+++ b/script/create_local_identity.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Creates a self-signed code-signing identity for local development.
+#
+# Why this exists: macOS privacy grants (Full Disk Access in particular) are pinned to a binary's
+# designated requirement. Ad-hoc signatures put the cdhash in that requirement, so every rebuild
+# invalidates the grant and you re-authorise the app by hand. A stable certificate produces a
+# requirement based on the certificate instead, and the grant survives rebuilds.
+#
+# A self-signed certificate is also safer here than a real Apple one: signing with an expired or
+# revoked certificate makes Gatekeeper treat the app as malicious and move it to the Bin, which is a
+# far worse failure than the ordinary "unidentified developer" prompt.
+set -euo pipefail
+
+IDENTITY_NAME="${M3MCP_IDENTITY:-M3MCP Local Development}"
+KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
+
+if security find-identity -p codesigning -v 2>/dev/null | grep -qF "$IDENTITY_NAME"; then
+  echo "Identity '$IDENTITY_NAME' already exists and is valid. Nothing to do."
+  exit 0
+fi
+
+if security find-identity -p codesigning 2>/dev/null | grep -qF "$IDENTITY_NAME"; then
+  echo "Identity '$IDENTITY_NAME' already exists (self-signed, so macOS reports it as untrusted —"
+  echo "that is expected and codesign still accepts it). Nothing to do."
+  exit 0
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+PASSWORD="m3mcp-local-$$"
+
+echo "Generating a self-signed code-signing certificate…"
+openssl req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes \
+  -keyout "$WORK_DIR/key.pem" -out "$WORK_DIR/cert.pem" \
+  -subj "/CN=$IDENTITY_NAME/O=M3MCP Local/C=DE" \
+  -addext "basicConstraints=critical,CA:false" \
+  -addext "keyUsage=critical,digitalSignature" \
+  -addext "extendedKeyUsage=critical,codeSigning" >/dev/null 2>&1
+
+# -legacy plus the SHA-1 algorithms are required: OpenSSL 3 defaults to a PKCS#12 MAC that the macOS
+# keychain cannot read, and the import fails with "MAC verification failed".
+openssl pkcs12 -export -legacy -macalg sha1 \
+  -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES \
+  -out "$WORK_DIR/identity.p12" -inkey "$WORK_DIR/key.pem" -in "$WORK_DIR/cert.pem" \
+  -name "$IDENTITY_NAME" -passout "pass:$PASSWORD" >/dev/null 2>&1
+
+# This certificate is a privilege, not just a build convenience: anything able to sign with it can
+# produce a binary satisfying the app's designated requirement — bundle identifier plus this
+# certificate — and thereby inherit the app's Full Disk Access grant. Verified: a stub binary signed
+# with this identity and carrying CFBundleIdentifier de.markzimmermann.m3mcp passes
+# `codesign --verify -R` against that requirement.
+#
+# So the default grants the key no standing access at all, and macOS prompts on each build. Neither
+# `-A` (any application) nor `-T /usr/bin/codesign` is used by default: `-A` lets malicious code sign
+# silently via Security.framework, and `-T /usr/bin/codesign` is barely better, since invoking
+# /usr/bin/codesign is something any process can do.
+IMPORT_ARGS=()
+if [[ -n "${M3MCP_ALLOW_CODESIGN_NOPROMPT:-}" ]]; then
+  echo "M3MCP_ALLOW_CODESIGN_NOPROMPT is set — allowing codesign to use the key without prompting."
+  echo "This weakens the protection described above. Prefer the default unless builds are frequent."
+  IMPORT_ARGS+=(-T /usr/bin/codesign)
+fi
+
+security import "$WORK_DIR/identity.p12" -k "$KEYCHAIN" -P "$PASSWORD" "${IMPORT_ARGS[@]}" >/dev/null
+
+if security find-identity -p codesigning 2>/dev/null | grep -qF "$IDENTITY_NAME"; then
+  echo "Created '$IDENTITY_NAME'."
+  echo
+  echo "macOS lists it as untrusted (CSSMERR_TP_NOT_TRUSTED) because it is self-signed."
+  echo "That is expected — codesign accepts it, and it is what keeps privacy grants stable."
+  echo
+  echo "SECURITY NOTE: treat this certificate as a privilege, not just a build convenience."
+  echo "The app's designated requirement is its bundle identifier plus this certificate, so anything"
+  echo "able to sign with it can satisfy that requirement and inherit the app's Full Disk Access."
+  echo "That is the trade-off for a grant that survives rebuilds; ad-hoc signing avoids the reusable"
+  echo "capability but forces you to re-authorise the app after every build."
+  echo
+  echo "The key was imported with no standing access, so macOS will ask for authentication the first"
+  echo "time each build signs with it. Choose \"Allow\", not \"Always Allow\" — \"Always Allow\" is"
+  echo "equivalent to the weaker setup this deliberately avoids."
+  echo
+  echo "To remove it later:"
+  echo "  security delete-identity -c \"$IDENTITY_NAME\""
+else
+  echo "Import reported success but the identity is not listed. Aborting." >&2
+  exit 1
+fi

--- a/script/install_local.sh
+++ b/script/install_local.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Installs M3MCP as a login-time background service.
+#
+# Differences from build_and_run.sh, which is meant for one-off runs:
+#
+#  - Installs outside the repository. If the checkout lives in an iCloud-managed folder (Desktop or
+#    Documents with "Desktop & Documents Folders" sync on), the file provider re-applies
+#    com.apple.FinderInfo to the bundle within a second of `xattr -cr`, and codesign then refuses to
+#    sign it. Staging under ~/Applications avoids that race entirely.
+#
+#  - Refuses expired or revoked certificates. build_and_run.sh picks the first identity matching
+#    "Apple Development", which may be expired or revoked. Signing with a revoked certificate makes
+#    macOS treat the app as malware and move it to the Bin — this script fails loudly instead.
+#
+#  - Runs the app from launchd rather than a shell. This matters for Full Disk Access: TCC evaluates
+#    the *responsible* process, so an app started from a terminal inherits the terminal's grant
+#    instead of using its own. Under launchd the app is its own responsible process, so the grant you
+#    give this bundle is the grant that applies.
+set -euo pipefail
+
+APP_NAME="M3MCPApp"
+BUNDLE_NAME="M3MCP"
+BUNDLE_ID="de.markzimmermann.m3mcp"
+CONFIGURATION="${M3MCP_CONFIGURATION:-release}"
+INSTALL_DIR="${M3MCP_INSTALL_DIR:-$HOME/Applications}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_BUNDLE="$INSTALL_DIR/$BUNDLE_NAME.app"
+APP_BINARY="$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+AGENT_PLIST="$HOME/Library/LaunchAgents/$BUNDLE_ID.plist"
+SOURCE_INFO_PLIST="$ROOT_DIR/Sources/$APP_NAME/Resources/Info.plist"
+
+# --- signing identity -------------------------------------------------------------------------
+
+pick_identity() {
+  if [[ -n "${M3MCP_CODESIGN_IDENTITY:-}" ]]; then
+    printf '%s' "$M3MCP_CODESIGN_IDENTITY"
+    return
+  fi
+  # A self-signed local identity is preferred: it cannot expire out from under you mid-project and
+  # gives a certificate-based designated requirement, so privacy grants survive rebuilds.
+  #
+  # Only expiry and revocation disqualify a certificate. CSSMERR_TP_NOT_TRUSTED is the normal state
+  # for a self-signed certificate and codesign accepts it, so it must not be filtered out.
+  local all
+  all="$(security find-identity -p codesigning 2>/dev/null || true)"
+  for name in "M3MCP Local Development" "Developer ID Application" "Apple Development"; do
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      if printf '%s' "$line" | grep -qE "CSSMERR_TP_CERT_(EXPIRED|REVOKED)"; then
+        local reason
+        reason="$(printf '%s' "$line" | sed 's/.*(\(CSSMERR[^)]*\)).*/\1/')"
+        echo "Skipping unusable identity ($reason): $name" >&2
+        continue
+      fi
+      printf '%s\n' "$line" | sed 's/.*"\(.*\)".*/\1/'
+      return
+    done < <(printf '%s\n' "$all" | grep -F "\"$name")
+  done
+}
+
+IDENTITY="$(pick_identity)"
+if [[ -z "$IDENTITY" ]]; then
+  cat >&2 <<EOF
+No usable code-signing identity found.
+
+Create a local one (recommended — keeps Full Disk Access working across rebuilds):
+  ./script/create_local_identity.sh
+
+Ad-hoc signing is deliberately not used here: its designated requirement contains the binary hash,
+so every rebuild silently invalidates the app's Full Disk Access grant.
+EOF
+  exit 1
+fi
+echo "Signing identity: $IDENTITY"
+
+# --- build ------------------------------------------------------------------------------------
+
+echo "Building ($CONFIGURATION)…"
+cd "$ROOT_DIR"
+swift build -c "$CONFIGURATION"
+BUILT_BINARY="$(swift build -c "$CONFIGURATION" --show-bin-path)/$APP_NAME"
+[[ -x "$BUILT_BINARY" ]] || { echo "Build produced no binary at $BUILT_BINARY" >&2; exit 1; }
+
+# --- stop the running instance ----------------------------------------------------------------
+
+if [[ -f "$AGENT_PLIST" ]]; then
+  launchctl bootout "gui/$UID/$BUNDLE_ID" 2>/dev/null || true
+fi
+pkill -x "$APP_NAME" 2>/dev/null || true
+
+# --- assemble the bundle ----------------------------------------------------------------------
+
+echo "Installing to $APP_BUNDLE"
+mkdir -p "$INSTALL_DIR"
+rm -rf "$APP_BUNDLE"
+mkdir -p "$APP_BUNDLE/Contents/MacOS"
+cp "$BUILT_BINARY" "$APP_BINARY"
+chmod +x "$APP_BINARY"
+cp "$SOURCE_INFO_PLIST" "$APP_BUNDLE/Contents/Info.plist"
+printf 'APPL????' > "$APP_BUNDLE/Contents/PkgInfo"
+xattr -cr "$APP_BUNDLE" 2>/dev/null || true
+
+# --- sign -------------------------------------------------------------------------------------
+
+codesign --force --sign "$IDENTITY" "$APP_BINARY" >/dev/null
+codesign --force --sign "$IDENTITY" "$APP_BUNDLE" >/dev/null
+codesign --verify --strict "$APP_BUNDLE"
+
+# The guard that matters. `spctl` reporting "rejected" is fine — that is the ordinary unidentified
+# developer verdict for a locally signed app. A revoked certificate is not fine: macOS would classify
+# the app as malware and delete it.
+ASSESSMENT="$(spctl --assess --type execute -vv "$APP_BUNDLE" 2>&1 || true)"
+if printf '%s' "$ASSESSMENT" | grep -q "CSSMERR_TP_CERT_REVOKED"; then
+  echo >&2
+  echo "ABORTING: '$IDENTITY' is REVOKED. Signing with it would make macOS treat this app as" >&2
+  echo "malware and move it to the Bin. Create a local identity instead:" >&2
+  echo "  ./script/create_local_identity.sh" >&2
+  rm -rf "$APP_BUNDLE"
+  exit 1
+fi
+
+# --- launch agent -----------------------------------------------------------------------------
+
+mkdir -p "$(dirname "$AGENT_PLIST")"
+cat > "$AGENT_PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$BUNDLE_ID</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$APP_BINARY</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+</dict>
+</plist>
+EOF
+
+launchctl bootstrap "gui/$UID" "$AGENT_PLIST" 2>/dev/null || launchctl load -w "$AGENT_PLIST"
+
+echo
+echo "Installed and started."
+echo
+echo "Grant Full Disk Access once, to this bundle:"
+echo "  System Settings -> Privacy & Security -> Full Disk Access -> +"
+echo "  $APP_BUNDLE"
+echo "then restart it:  launchctl kickstart -k gui/$UID/$BUNDLE_ID"
+echo
+echo "Because the signature uses a stable certificate, that grant persists across future rebuilds."
+echo
+echo "Manage:"
+echo "  launchctl kickstart -k gui/$UID/$BUNDLE_ID   # restart"
+echo "  launchctl bootout gui/$UID/$BUNDLE_ID        # stop until next login"
+echo "  rm $AGENT_PLIST                              # uninstall the agent"


### PR DESCRIPTION
Adds a second install path for running M3MCP as a daily service, alongside `build_and_run.sh` for one-off runs.

Each change below fixes something that cost real debugging time, so the reasoning lives in the scripts rather than only here.

## `build_and_run.sh` can sign with a revoked certificate — and macOS then deletes the app

The identity search takes the first match for `Apple Development`. On my machine that resolved to a **revoked** certificate, and `spctl` reports:

```
CSSMERR_TP_CERT_REVOKED
```

Signing with a revoked certificate is not the ordinary "unidentified developer" case. macOS classifies the app as malicious, blocks it, and moves it to the Bin — which is exactly what happened to me before I understood why. `open` failed with `Launchd job spawn failed` and the bundle vanished.

For comparison, an ad-hoc signature assesses as plain `rejected`, which is harmless.

`install_local.sh` therefore:
- skips identities reporting `CSSMERR_TP_CERT_EXPIRED` or `CSSMERR_TP_CERT_REVOKED` when choosing
- re-checks `spctl` **after** signing and aborts rather than installing something macOS will destroy
- explicitly tolerates `CSSMERR_TP_NOT_TRUSTED`, which is the normal state of a self-signed certificate

I had two unusable certificates with the same common name — one expired, one revoked — and `find-identity -v` lists the revoked one as valid, because revocation is only caught by the online check. So filtering on `-v` alone is not sufficient.

## `codesign` cannot sign inside an iCloud-managed folder

With "Desktop & Documents Folders" sync enabled and the checkout under `~/Documents`, the file provider re-applies `com.apple.FinderInfo` to `dist/M3MCP.app` **within a second** of the script's `xattr -cr`. I measured the reappearance. `codesign` then refuses:

```
resource fork, Finder information, or similar detritus not allowed
```

Under `set -e` the script aborts before launching anything, so the symptom is simply that nothing happens. Installing to `~/Applications` avoids the race entirely.

## Full Disk Access does not follow a shell-launched app

This one is subtle and cost the most time. TCC evaluates the **responsible process**, not the executable. An app started from a terminal inherits the *terminal's* grant, so granting FDA to the binary appears to do nothing at all — the app still reports the store as unreadable while an `sqlite3` command in a granted Terminal reads it fine.

Running from a LaunchAgent makes the app its own responsible process, so the grant given to the bundle is the grant that applies. It also starts at login with no terminal window, and `applicationShouldTerminateAfterLastWindowClosed` already returns `false`, so closing the window leaves the server running.

## `create_local_identity.sh`

Generates the self-signed `M3MCP Local Development` identity that `build_and_run.sh` already prefers but which nothing creates.

A stable certificate matters beyond convenience. Privacy grants are pinned to a binary's designated requirement, and an ad-hoc signature puts the **code hash** there:

```
ad-hoc:      identifier "…" and cdhash H"…"     ← changes every rebuild
certificate: identifier "…" and certificate root = H"…"   ← stable
```

So with ad-hoc signing, every rebuild silently invalidates Full Disk Access. Verified the fix by rebuilding until the cdhash actually changed (`0d09…` → `b010…`) and confirming the grant survived with no re-authorisation.

### Security trade-off, stated explicitly

That same stability makes the certificate a privilege rather than a build convenience. Anything able to sign with it can produce a binary satisfying the app's designated requirement and thereby inherit Full Disk Access. Verified: a stub binary signed with this identity and carrying `CFBundleIdentifier de.markzimmermann.m3mcp` passes `codesign --verify -R` against that requirement.

The key is therefore imported with **no standing access**, so macOS prompts per build. `-A` is deliberately not used, and neither is `-T /usr/bin/codesign` by default — `-A` lets malicious code sign silently via Security.framework, and `-T /usr/bin/codesign` is barely better since invoking `codesign` is something any process can do. `M3MCP_ALLOW_CODESIGN_NOPROMPT=1` opts into the convenient-but-weaker setup.

Ad-hoc signing has the inverse profile: no reusable capability, but no durable grant either. Both are defensible; the trade-off is documented so the choice is deliberate.

## Usage

```bash
./script/create_local_identity.sh   # once
./script/install_local.sh           # build, sign, install, start
```

Then grant Full Disk Access to `~/Applications/M3MCP.app` once. Subsequent `install_local.sh` runs keep the grant.

Env vars: `M3MCP_INSTALL_DIR`, `M3MCP_CONFIGURATION`, `M3MCP_CODESIGN_IDENTITY`.

`build_and_run.sh` is left untouched — this is additive. If you would rather fold the revoked-certificate guard into it directly, I am happy to do that instead.

## Verification

Ran on macOS 26.5.2: builds release, installs to `~/Applications`, signs with the local identity, loads the LaunchAgent, app comes up under `launchd` with parent PID 1, endpoint reachable, all seven providers `authorized`, and the FDA grant survived repeated clean rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
