### PR TITLE
Reject browser-originated and DNS-rebound requests on the loopback endpoint

### DIFF
--- a/Sources/M3MCPApp/Services/LocalHTTPServer.swift
+++ b/Sources/M3MCPApp/Services/LocalHTTPServer.swift
@@ -76,6 +76,56 @@ final class LocalHTTPServer {
         let method: String
         let path: String
         let body: Data
+        /// Header names lowercased, so lookups do not depend on client casing.
+        let headers: [String: String]
+    }
+
+    /// Rejects requests a browser could have made.
+    ///
+    /// The endpoint is loopback-only, which stops remote hosts but not web pages: a page can POST to
+    /// 127.0.0.1. With `Content-Type: text/plain` that is a CORS "simple request", so it is sent with
+    /// no preflight and the tool runs. Responses are not readable cross-origin, but the side effects
+    /// happen — and absent Host validation, DNS rebinding makes an attacker domain resolve to
+    /// 127.0.0.1, become same-origin, and read every response.
+    ///
+    /// `M3MCPBridge` uses URLSession against a literal loopback address, so it sends none of the
+    /// browser-only headers and always sends `application/json`. These checks are therefore invisible
+    /// to legitimate callers.
+    private enum RequestGuard {
+        /// Present only on browser-issued requests. URLSession never sets them.
+        static let browserOnlyHeaders = ["origin", "referer", "sec-fetch-site", "sec-fetch-mode"]
+
+        static let allowedHosts: Set<String> = ["127.0.0.1", "localhost", "[::1]", "::1"]
+
+        /// Returns a rejection reason, or nil when the request is acceptable.
+        static func rejection(for request: HTTPRequest) -> String? {
+            for header in browserOnlyHeaders where request.headers[header] != nil {
+                return "Requests carrying '\(header)' are refused: this endpoint is not reachable from a browser."
+            }
+
+            if let host = request.headers["host"] {
+                // Strip the port, keeping IPv6 brackets intact.
+                let hostname: String
+                if host.hasPrefix("["), let close = host.firstIndex(of: "]") {
+                    hostname = String(host[...close])
+                } else {
+                    hostname = host.split(separator: ":").first.map(String.init) ?? host
+                }
+                guard allowedHosts.contains(hostname.lowercased()) else {
+                    return "Unexpected Host '\(host)'. Only loopback names are accepted, which blocks DNS rebinding."
+                }
+            }
+
+            // Enforced on tool calls only, so /health stays trivially checkable.
+            if request.method == "POST", request.path.hasPrefix("/tools/") {
+                let contentType = request.headers["content-type"] ?? ""
+                guard contentType.lowercased().contains("application/json") else {
+                    return "Tool calls require Content-Type: application/json."
+                }
+            }
+
+            return nil
+        }
     }
 
     private func parseRequest(_ data: Data) -> HTTPRequest? {
@@ -98,13 +148,13 @@ final class LocalHTTPServer {
             return nil
         }
 
-        var contentLength = 0
+        var headers: [String: String] = [:]
         for line in lines.dropFirst() {
             let pair = line.split(separator: ":", maxSplits: 1).map(String.init)
-            if pair.count == 2, pair[0].lowercased() == "content-length" {
-                contentLength = Int(pair[1].trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
-            }
+            guard pair.count == 2 else { continue }
+            headers[pair[0].lowercased()] = pair[1].trimmingCharacters(in: .whitespacesAndNewlines)
         }
+        let contentLength = Int(headers["content-length"] ?? "") ?? 0
 
         let bodyStart = headerEnd.upperBound
         guard data.count >= bodyStart + contentLength else {
@@ -112,10 +162,20 @@ final class LocalHTTPServer {
         }
 
         let body = data[bodyStart..<(bodyStart + contentLength)]
-        return HTTPRequest(method: String(parts[0]), path: String(parts[1]), body: Data(body))
+        return HTTPRequest(
+            method: String(parts[0]),
+            path: String(parts[1]),
+            body: Data(body),
+            headers: headers
+        )
     }
 
     private func respond(to request: HTTPRequest, on connection: NWConnection) async {
+        if let reason = RequestGuard.rejection(for: request) {
+            send(status: 403, body: ["error": reason], on: connection)
+            return
+        }
+
         if request.method == "GET", request.path == "/health" || request.path == "/status" {
             let status = await statusHandler()
             send(status: 200, codable: status, on: connection)
@@ -155,6 +215,7 @@ final class LocalHTTPServer {
         switch status {
         case 200: reason = "OK"
         case 400: reason = "Bad Request"
+        case 403: reason = "Forbidden"
         case 404: reason = "Not Found"
         case 413: reason = "Payload Too Large"
         default: reason = "Internal Server Error"


### PR DESCRIPTION
Loopback binding keeps remote hosts out, but it does not keep **browsers** out — a web page can POST to `127.0.0.1`.

Verified against the running server before the change:

| Request | Before |
|---|---|
| `POST /tools/…` with `Content-Type: text/plain` | **200** |
| same, with `Origin: https://evil.example` | **200** |
| same, with `Host: evil.example` | **200** |

`text/plain` makes it a CORS **simple request**, so it is sent with no preflight and the tool executes.

## Why this matters

**Today:** side effects fire blind from any page the user visits — `permissions_request`, `ai_image_playground`, or repeated transcription. Responses are not readable cross-origin because no CORS headers are returned.

**With DNS rebinding:** absent `Host` validation, an attacker points their own domain at `127.0.0.1`, becomes same-origin with the endpoint, and reads **every response** — mail, contacts, and whatever else providers expose.

## The change

Three checks in a `RequestGuard`, all invisible to legitimate callers because `M3MCPBridge` uses `URLSession` against a literal loopback address:

1. **Reject browser-only headers** — `Origin`, `Referer`, `Sec-Fetch-Site`, `Sec-Fetch-Mode`. URLSession never sets these; browsers always do.
2. **Require a loopback `Host`** — `127.0.0.1`, `localhost`, `[::1]`. This is what actually blocks rebinding. Port is stripped, IPv6 brackets preserved.
3. **Require `application/json` on tool calls** — removes the simple-request path. `GET /health` is deliberately left unrestricted so it stays trivially checkable.

Rejections return `403` with a short reason.

Parsing changed slightly to keep all headers (lowercased keys) rather than only `Content-Length`.

## Verification

Still works: legitimate JSON POST, JSON with `charset=utf-8`, `GET /health`, and an end-to-end bridge `tools/call` (`ok: true`, 6 items).

Now refused with 403: `text/plain`, `application/x-www-form-urlencoded`, `Origin`, `Referer`, `Sec-Fetch-Site`, and a rebound `Host`.

No configuration, no changes needed to existing MCP client setups.

## Out of scope

This does **not** make the endpoint authenticated. Any local process can still use the app's Full Disk Access by proxy — reading Mail, Contacts and voice-memo transcripts it has no permission to read itself, including sandboxed apps. That is a confused-deputy problem needing a shared secret or a Unix domain socket, which changes the app/bridge contract, so it is filed as a separate issue rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
