### PR TITLE
Transcribe voice memos through the macOS 26 speech stack, with fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ AppleMCP consists of a SwiftUI app that bridges macOS privacy-controlled APIs an
 | **Reminders** | EventKit | Reminders Access |
 | **Notes** | Notes.app AppleScript Automation | Automation Permission |
 | **Photos** | Photos.framework | Photos Access |
-| **Voice Memos** | Local `CloudRecordings.db` + in-file transcripts, Speech.framework for on-device recognition | Full Disk Access, Speech Recognition (only for `voicememos_transcribe`) |
+| **Voice Memos** | Local `CloudRecordings.db` + in-file transcripts, SpeechAnalyzer / SFSpeechRecognizer for recordings without one | Full Disk Access, Speech Recognition (only for `voicememos_transcribe`) |
 | **Apple Intelligence** | Native APIs (ImagePlayground, Translation, Writing Tools) | None |
 | **Foundation Models** | On-device language model via FoundationModels (macOS 26, weak-linked) | None |
 
@@ -84,7 +84,7 @@ The M3MCP UI app must be running for MCP calls to work. The bridge talks to the 
 | `voicememos_read` | Read one recording including its stored transcript |
 | `voicememos_transcript` | Return a stored transcript as text, timestamped text, or JSON segments |
 | `voicememos_audio` | Return the recording as a local path or base64 audio |
-| `voicememos_transcribe` | Transcribe a recording with on-device speech recognition |
+| `voicememos_transcribe` | Transcribe on device: stored transcript, cache, SpeechAnalyzer (macOS 26), then SFSpeechRecognizer |
 
 ### Apple Intelligence
 

--- a/Sources/M3MCPApp/Providers/PermissionProvider.swift
+++ b/Sources/M3MCPApp/Providers/PermissionProvider.swift
@@ -337,7 +337,7 @@ final class PermissionProvider {
     }
 
     private func speechRecognitionStatusItem(prompt: Bool) async -> DataItem {
-        let state = await SpeechTranscriber.authorizationState(prompt: prompt)
+        let state = await LegacySpeechRecognizer.authorizationState(prompt: prompt)
         let hint = state == "authorized"
             ? nil
             : "Only needed for voicememos_transcribe. Stored Voice Memos transcripts are read without it."

--- a/Sources/M3MCPApp/Providers/VoiceMemosProvider.swift
+++ b/Sources/M3MCPApp/Providers/VoiceMemosProvider.swift
@@ -130,6 +130,18 @@ final class VoiceMemosProvider {
         do {
             let row = try loadRecording(id: id)
             guard let transcript = row.transcript() else {
+                // No atom in the recording, but this app may have transcribed it before.
+                if let cached = row.cachedTranscript() {
+                    return transcriptResponse(
+                        row: row,
+                        text: cached,
+                        origin: "cache",
+                        locale: nil,
+                        segments: [],
+                        message: "This transcript was produced by voicememos_transcribe; macOS stored none in the recording, so there are no timestamps."
+                    )
+                }
+
                 return ToolResponse(
                     ok: false,
                     source: sourceName,
@@ -268,6 +280,12 @@ final class VoiceMemosProvider {
         }
     }
 
+    /// Produces a transcript, cheapest source first.
+    ///
+    /// 1. the transcript macOS stored inside the recording — free, and the only option before macOS 26
+    /// 2. a transcript this app produced earlier, keyed on the recording's digest
+    /// 3. `SpeechAnalyzer` on macOS 26, the engine Voice Memos itself uses
+    /// 4. `SFSpeechRecognizer` below that, so macOS 15 to 25 can still transcribe
     func transcribe(input: [String: JSONValue]) async -> ToolResponse {
         let id = input.string("id")
         guard !id.isEmpty else {
@@ -282,27 +300,28 @@ final class VoiceMemosProvider {
         do {
             let row = try loadRecording(id: id)
 
-            if preferStored, let stored = row.transcript() {
-                var metadata = baseMetadata(row)
-                metadata["locale"] = stored.locale
-                metadata["segment_count"] = String(stored.segments.count)
-                metadata["origin"] = "stored"
+            if preferStored {
+                if let stored = row.transcript() {
+                    return transcriptResponse(
+                        row: row,
+                        text: stored.text,
+                        origin: "stored",
+                        locale: stored.locale,
+                        segments: stored.segments,
+                        message: "Returned the transcript macOS already stored in the recording. Set prefer_stored to false to re-run speech recognition."
+                    )
+                }
 
-                let item = DataItem(
-                    id: row.id,
-                    title: row.title,
-                    subtitle: row.subtitle.isEmpty ? nil : row.subtitle,
-                    kind: "voice_memo_transcript",
-                    source: sourceName,
-                    preview: stored.text,
-                    metadata: metadata
-                )
-                return ToolResponse(
-                    ok: true,
-                    source: sourceName,
-                    items: [item],
-                    message: "Returned the transcript macOS already stored in the recording. Set prefer_stored to false to re-run speech recognition."
-                )
+                if let cached = row.cachedTranscript() {
+                    return transcriptResponse(
+                        row: row,
+                        text: cached,
+                        origin: "cache",
+                        locale: nil,
+                        segments: [],
+                        message: "Returned a transcript this app produced earlier. Set prefer_stored to false to re-run speech recognition."
+                    )
+                }
             }
 
             guard let fileURL = row.fileURL else {
@@ -313,34 +332,79 @@ final class VoiceMemosProvider {
                 )
             }
 
-            let result = try await LegacySpeechRecognizer.transcribe(url: fileURL, languageCode: language, timeout: timeout)
-
-            var metadata = baseMetadata(row)
-            metadata["locale"] = result.locale
-            metadata["segment_count"] = String(result.segments.count)
-            metadata["on_device"] = String(result.onDevice)
-            metadata["origin"] = "speech_recognition"
-            if let encoded = encodeSegments(result.segments) {
-                metadata["segments_json"] = encoded
+            if SpeechTranscription.isSupported {
+                do {
+                    let text = try await SpeechTranscription.transcribe(url: fileURL, locale: Locale(identifier: language))
+                    TranscriptCache.write(text, digest: row.digest)
+                    return transcriptResponse(
+                        row: row,
+                        text: text,
+                        origin: "speech_analyzer",
+                        locale: language,
+                        segments: [],
+                        message: nil
+                    )
+                } catch let failure as TranscriptionFailure {
+                    // Fall through to the older recognizer rather than failing outright: the model may
+                    // simply be missing for this locale, which SFSpeechRecognizer can still cover.
+                    AppLogger.log("SpeechAnalyzer unavailable, falling back: \(failure.localizedDescription)")
+                }
             }
 
-            let item = DataItem(
-                id: row.id,
-                title: row.title,
-                subtitle: row.subtitle.isEmpty ? nil : row.subtitle,
-                kind: "voice_memo_transcript",
-                source: sourceName,
-                preview: result.text,
-                metadata: metadata
+            let result = try await LegacySpeechRecognizer.transcribe(url: fileURL, languageCode: language, timeout: timeout)
+            TranscriptCache.write(result.text, digest: row.digest)
+            return transcriptResponse(
+                row: row,
+                text: result.text,
+                origin: "speech_recognition",
+                locale: result.locale,
+                segments: result.segments,
+                onDevice: result.onDevice,
+                message: nil
             )
-            return ToolResponse(ok: true, source: sourceName, items: [item])
         } catch let failure as LegacySpeechRecognizer.Failure {
             return ToolResponse(ok: false, source: sourceName, message: failure.message)
+        } catch let failure as TranscriptionFailure {
+            return ToolResponse(ok: false, source: sourceName, message: failure.localizedDescription)
         } catch let failure as VoiceMemoStoreFailure {
             return ToolResponse(ok: false, source: sourceName, message: failure.message)
         } catch {
             return ToolResponse(ok: false, source: sourceName, message: error.localizedDescription)
         }
+    }
+
+    private func transcriptResponse(
+        row: RecordingRow,
+        text: String,
+        origin: String,
+        locale: String?,
+        segments: [VoiceMemoTranscript.Segment],
+        onDevice: Bool? = nil,
+        message: String?
+    ) -> ToolResponse {
+        var metadata = baseMetadata(row)
+        metadata["origin"] = origin
+        metadata["segment_count"] = String(segments.count)
+        if let locale {
+            metadata["locale"] = locale
+        }
+        if let onDevice {
+            metadata["on_device"] = String(onDevice)
+        }
+        if !segments.isEmpty, let encoded = encodeSegments(segments) {
+            metadata["segments_json"] = encoded
+        }
+
+        let item = DataItem(
+            id: row.id,
+            title: row.title,
+            subtitle: row.subtitle.isEmpty ? nil : row.subtitle,
+            kind: "voice_memo_transcript",
+            source: sourceName,
+            preview: text,
+            metadata: metadata
+        )
+        return ToolResponse(ok: true, source: sourceName, items: [item], message: message)
     }
 
     /// Reports whether the local Voice Memos store is readable, mirroring the Mail index preflight.
@@ -377,6 +441,8 @@ final class VoiceMemosProvider {
         let filename: String
         let fileURL: URL?
         let deletedAt: Date?
+        /// `ZAUDIODIGEST`, used as the transcript cache key.
+        let digest: String?
 
         var subtitle: String {
             var parts: [String] = []
@@ -389,14 +455,22 @@ final class VoiceMemosProvider {
             return parts.joined(separator: " · ")
         }
 
+        /// Transcript stored inside the recording by macOS, if any.
         func transcript() -> VoiceMemoTranscript? {
             guard let fileURL else { return nil }
             return VoiceMemoTranscriptReader.read(at: fileURL)
         }
 
+        /// Transcript this app produced earlier, keyed on the recording's digest.
+        func cachedTranscript() -> String? {
+            TranscriptCache.read(digest: digest)
+        }
+
         func hasTranscript() -> Bool {
-            guard let fileURL else { return false }
-            return VoiceMemoTranscriptReader.hasTranscript(at: fileURL)
+            if let fileURL, VoiceMemoTranscriptReader.hasTranscript(at: fileURL) {
+                return true
+            }
+            return TranscriptCache.has(digest: digest)
         }
 
         static let displayFormatter: DateFormatter = {
@@ -701,6 +775,7 @@ final class VoiceMemosProvider {
         let date = dateValue(statement, column: 4)
         let duration = doubleValue(statement, column: 5) ?? 0
         let deletedAt = dateValue(statement, column: 6)
+        let digest = blobHexValue(statement, column: 7) ?? textValue(statement, column: 7)
 
         let filename = path.isEmpty ? "" : URL(fileURLWithPath: path).lastPathComponent
         let fileURL = resolveRecording(path: path, store: store)
@@ -721,7 +796,8 @@ final class VoiceMemosProvider {
             duration: duration,
             filename: filename,
             fileURL: fileURL,
-            deletedAt: deletedAt
+            deletedAt: deletedAt,
+            digest: digest
         )
     }
 
@@ -750,6 +826,7 @@ final class VoiceMemosProvider {
         let date: String?
         let duration: String?
         let evictionDate: String?
+        let digest: String?
     }
 
     private func selectClause(for schema: RecordingSchema) -> String {
@@ -760,7 +837,8 @@ final class VoiceMemosProvider {
             schema.title.map(quote) ?? "NULL",
             schema.date.map(quote) ?? "NULL",
             schema.duration.map(quote) ?? "NULL",
-            schema.evictionDate.map(quote) ?? "NULL"
+            schema.evictionDate.map(quote) ?? "NULL",
+            schema.digest.map(quote) ?? "NULL"
         ].joined(separator: ", ")
     }
 
@@ -776,7 +854,8 @@ final class VoiceMemosProvider {
             title: pick(columns, ["ZENCRYPTEDTITLE", "ZTITLE"]),
             date: pick(columns, ["ZDATE", "ZCREATIONDATE"]),
             duration: pick(columns, ["ZDURATION"]),
-            evictionDate: pick(columns, ["ZEVICTIONDATE"])
+            evictionDate: pick(columns, ["ZEVICTIONDATE"]),
+            digest: pick(columns, ["ZAUDIODIGEST"])
         )
     }
 
@@ -882,6 +961,21 @@ final class VoiceMemosProvider {
             return nil
         }
         return String(cString: value)
+    }
+
+    /// `ZAUDIODIGEST` is a BLOB; its hex form is stable and makes a usable cache key.
+    private func blobHexValue(_ statement: OpaquePointer, column: Int32) -> String? {
+        guard sqlite3_column_type(statement, column) == SQLITE_BLOB,
+              let bytes = sqlite3_column_blob(statement, column)
+        else {
+            return nil
+        }
+
+        let count = Int(sqlite3_column_bytes(statement, column))
+        guard count > 0 else { return nil }
+        return UnsafeRawBufferPointer(start: bytes, count: count)
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 
     private func doubleValue(_ statement: OpaquePointer, column: Int32) -> Double? {

--- a/Sources/M3MCPApp/Providers/VoiceMemosProvider.swift
+++ b/Sources/M3MCPApp/Providers/VoiceMemosProvider.swift
@@ -276,7 +276,7 @@ final class VoiceMemosProvider {
 
         let requestedLanguage = input.string("language").trimmingCharacters(in: .whitespacesAndNewlines)
         let language = requestedLanguage.isEmpty ? Locale.current.identifier : requestedLanguage
-        let timeout = TimeInterval(max(10, min(input.int("timeout_seconds", default: Int(SpeechTranscriber.defaultTimeout)), 1_800)))
+        let timeout = TimeInterval(max(10, min(input.int("timeout_seconds", default: Int(LegacySpeechRecognizer.defaultTimeout)), 1_800)))
         let preferStored = input.bool("prefer_stored", default: true)
 
         do {
@@ -313,7 +313,7 @@ final class VoiceMemosProvider {
                 )
             }
 
-            let result = try await SpeechTranscriber.transcribe(url: fileURL, languageCode: language, timeout: timeout)
+            let result = try await LegacySpeechRecognizer.transcribe(url: fileURL, languageCode: language, timeout: timeout)
 
             var metadata = baseMetadata(row)
             metadata["locale"] = result.locale
@@ -334,7 +334,7 @@ final class VoiceMemosProvider {
                 metadata: metadata
             )
             return ToolResponse(ok: true, source: sourceName, items: [item])
-        } catch let failure as SpeechTranscriber.Failure {
+        } catch let failure as LegacySpeechRecognizer.Failure {
             return ToolResponse(ok: false, source: sourceName, message: failure.message)
         } catch let failure as VoiceMemoStoreFailure {
             return ToolResponse(ok: false, source: sourceName, message: failure.message)

--- a/Sources/M3MCPApp/Services/LocalMCPService.swift
+++ b/Sources/M3MCPApp/Services/LocalMCPService.swift
@@ -22,7 +22,14 @@ final class LocalMCPService {
             ServiceHealth(name: "Reminders", endpoint: "eventkit://reminders", mode: "EventKit", state: "on-demand"),
             ServiceHealth(name: "Notes", endpoint: "macos://Notes.app", mode: "AppleScript", state: "on-demand"),
             ServiceHealth(name: "Photos", endpoint: "photos://library", mode: "Photos.framework", state: "on-demand"),
-            ServiceHealth(name: "Voice Memos", endpoint: "voicememos://local-store", mode: "CloudRecordings store + Speech", state: "on-demand"),
+            ServiceHealth(
+                name: "Voice Memos",
+                endpoint: "voicememos://local-store",
+                mode: "CloudRecordings store + on-device transcription",
+                // Reported live rather than as "on-demand": when transcription is unavailable the
+                // reason is the useful part, and source_status is where a caller looks for it.
+                state: SpeechTranscription.statusDescription
+            ),
             ServiceHealth(name: "Apple Intelligence", endpoint: "macos://intelligence", mode: "AppleScript/Shortcuts/URL scheme", state: "on-demand"),
             ServiceHealth(
                 name: "Foundation Models",

--- a/Sources/M3MCPApp/Support/LegacySpeechRecognizer.swift
+++ b/Sources/M3MCPApp/Support/LegacySpeechRecognizer.swift
@@ -2,11 +2,15 @@ import Foundation
 import M3MCPCore
 import Speech
 
-/// On-device speech recognition for recordings that carry no stored transcript.
+/// `SFSpeechRecognizer` transcription, used where the macOS 26 speech stack is unavailable.
 ///
-/// The recognition request runs inside M3MCPApp so macOS attributes the Speech Recognition
-/// permission to the signed app bundle instead of the MCP bridge process.
-enum SpeechTranscriber {
+/// `SpeechTranscription` is the preferred path: it drives `SpeechAnalyzer`, the same engine Voice
+/// Memos itself uses. This one keeps transcription working on macOS 15 to 25, where that stack does
+/// not exist. Both run inside M3MCPApp, so macOS attributes the Speech Recognition permission to the
+/// signed app bundle rather than to the MCP bridge process.
+///
+/// Named to stay clear of `Speech.SpeechTranscriber`, the macOS 26 type the other path uses.
+enum LegacySpeechRecognizer {
     struct Result {
         let text: String
         let segments: [VoiceMemoTranscript.Segment]

--- a/Sources/M3MCPApp/Support/SpeechTranscription.swift
+++ b/Sources/M3MCPApp/Support/SpeechTranscription.swift
@@ -1,0 +1,301 @@
+import AVFoundation
+import Foundation
+import Speech
+
+enum TranscriptionFailure: Error, LocalizedError {
+    case requiresNewerOS
+    case unavailable
+    case unsupportedLocale(requested: String)
+    case unsupportedAudio(String)
+    case failed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .requiresNewerOS:
+            return "Transcription requires macOS 26 or newer. Memo metadata is still available on this system."
+        case .unavailable:
+            return "The on-device speech model is not available on this Mac."
+        case .unsupportedLocale(let requested):
+            return "No on-device speech model matches the locale \(requested)."
+        case .unsupportedAudio(let detail):
+            return "Unsupported audio format: \(detail)"
+        case .failed(let detail):
+            return detail
+        }
+    }
+}
+
+/// Transcribes recordings with Apple's on-device speech models.
+///
+/// `SpeechTranscriber` / `SpeechAnalyzer` are the Apple Intelligence speech stack introduced in
+/// macOS 26 — the same engine Voice Memos and Notes use for their own transcripts. Nothing leaves
+/// the machine and no third-party recogniser is involved.
+///
+/// AppleMCP has to do this itself: Voice Memos computes transcripts lazily inside the app and
+/// persists nothing on disk, so a memo recorded on iPhone has no transcript to read on the Mac.
+enum SpeechTranscription {
+    static var isSupported: Bool {
+        if #available(macOS 26, *) {
+            return SpeechTranscriber.isAvailable
+        }
+        return false
+    }
+
+    /// Human-readable capability line for `permissions_status`.
+    static var statusDescription: String {
+        if #available(macOS 26, *) {
+            return SpeechTranscriber.isAvailable
+                ? "On-device Apple speech model available."
+                : "On-device Apple speech model unavailable on this Mac."
+        }
+        return "Transcription requires macOS 26; metadata-only on this system."
+    }
+
+    static func transcribe(url: URL, locale: Locale) async throws -> String {
+        guard #available(macOS 26, *) else {
+            throw TranscriptionFailure.requiresNewerOS
+        }
+        guard SpeechTranscriber.isAvailable else {
+            throw TranscriptionFailure.unavailable
+        }
+
+        let resolved = await SpeechTranscriber.supportedLocale(equivalentTo: locale)
+        guard let resolved else {
+            throw TranscriptionFailure.unsupportedLocale(requested: locale.identifier)
+        }
+
+        let transcriber = SpeechTranscriber(locale: resolved, preset: .transcription)
+
+        // First use of a locale downloads its model. `assetInstallationRequest` returns nil once
+        // everything needed is already installed.
+        do {
+            if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+                try await request.downloadAndInstall()
+            }
+        } catch {
+            throw TranscriptionFailure.failed("Could not install the speech model for \(resolved.identifier): \(error.localizedDescription)")
+        }
+
+        let audioFile = try await openAudio(at: url)
+
+        let analyzer = SpeechAnalyzer(modules: [transcriber])
+
+        // Start collecting before analysis so no early results are dropped. The sequence ends
+        // when the analyzer finishes.
+        let collector = Task {
+            var transcript = AttributedString()
+            for try await result in transcriber.results where result.isFinal {
+                transcript += result.text
+            }
+            return String(transcript.characters)
+        }
+
+        do {
+            let lastSample = try await analyzer.analyzeSequence(from: audioFile)
+            if let lastSample {
+                try await analyzer.finalizeAndFinish(through: lastSample)
+            } else {
+                await analyzer.cancelAndFinishNow()
+            }
+        } catch {
+            collector.cancel()
+            throw TranscriptionFailure.failed("Transcription failed: \(error.localizedDescription)")
+        }
+
+        do {
+            return try await collector.value.trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            throw TranscriptionFailure.failed("Could not read transcription results: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Audio input
+
+    /// Opens the recording as an `AVAudioFile`, transcoding first when the container needs it.
+    ///
+    /// Most memos are plain `.m4a`. Edited recordings are stored as `.qta`, which `AVAudioFile`
+    /// cannot always open directly, so those are decoded through `AVAssetReader` into a scratch
+    /// CAF file first.
+    private static func openAudio(at url: URL) async throws -> AVAudioFile {
+        if let file = try? AVAudioFile(forReading: url) {
+            AppLogger.log("Transcription: \(url.lastPathComponent) opened directly, format \(file.processingFormat), frames \(file.length)")
+            return file
+        }
+        AppLogger.log("Transcription: \(url.lastPathComponent) not readable by AVAudioFile — falling back to AVAssetReader transcode")
+        let transcoded = try await transcodeToScratchFile(url: url)
+        do {
+            return try AVAudioFile(forReading: transcoded)
+        } catch {
+            throw TranscriptionFailure.unsupportedAudio("\(url.lastPathComponent) (\(error.localizedDescription))")
+        }
+    }
+
+    private static func transcodeToScratchFile(url: URL) async throws -> URL {
+        let asset = AVURLAsset(url: url)
+
+        let tracks: [AVAssetTrack]
+        do {
+            tracks = try await asset.loadTracks(withMediaType: .audio)
+        } catch {
+            throw TranscriptionFailure.unsupportedAudio("\(url.lastPathComponent) could not be opened by AVFoundation (\(error.localizedDescription))")
+        }
+
+        guard let track = tracks.first else {
+            throw TranscriptionFailure.unsupportedAudio("\(url.lastPathComponent) contains no audio track")
+        }
+
+        // Edited recordings can carry more than one audio track — a stereo mix alongside a
+        // multichannel spatial one. Which track comes first is not guaranteed, so log the choice;
+        // transcribing the wrong one would silently degrade the transcript rather than fail.
+        if tracks.count > 1 {
+            AppLogger.log("Transcription: \(url.lastPathComponent) has \(tracks.count) audio tracks; using track id \(track.trackID)")
+        }
+
+        let reader: AVAssetReader
+        do {
+            reader = try AVAssetReader(asset: asset)
+        } catch {
+            throw TranscriptionFailure.unsupportedAudio("\(url.lastPathComponent) is not readable (\(error.localizedDescription))")
+        }
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsFloatKey: true,
+            AVLinearPCMIsNonInterleaved: false,
+            AVLinearPCMIsBigEndianKey: false
+        ]
+        let output = AVAssetReaderTrackOutput(track: track, outputSettings: settings)
+        guard reader.canAdd(output) else {
+            throw TranscriptionFailure.unsupportedAudio("\(url.lastPathComponent) cannot be decoded to PCM")
+        }
+        reader.add(output)
+
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("m3mcp-transcode-\(UUID().uuidString).caf")
+
+        guard reader.startReading() else {
+            throw TranscriptionFailure.unsupportedAudio("\(url.lastPathComponent) could not be read (\(reader.error?.localizedDescription ?? "unknown error"))")
+        }
+
+        var writer: AVAudioFile?
+        var writeFailure: Error?
+
+        while let sampleBuffer = output.copyNextSampleBuffer() {
+            guard let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer),
+                  let streamDescription = CMAudioFormatDescriptionGetStreamBasicDescription(formatDescription),
+                  let format = AVAudioFormat(streamDescription: streamDescription) else {
+                CMSampleBufferInvalidate(sampleBuffer)
+                continue
+            }
+
+            if writer == nil {
+                do {
+                    writer = try AVAudioFile(forWriting: destination, settings: format.settings)
+                } catch {
+                    throw TranscriptionFailure.unsupportedAudio("Could not create a scratch file for \(url.lastPathComponent) (\(error.localizedDescription))")
+                }
+            }
+
+            if let buffer = pcmBuffer(from: sampleBuffer, format: format) {
+                do {
+                    try writer?.write(from: buffer)
+                } catch {
+                    // Keep the first failure. Swallowing these would yield a zero-frame file that
+                    // reads back fine and transcribes to an empty string — a wrong answer dressed
+                    // up as "no speech in this recording".
+                    if writeFailure == nil { writeFailure = error }
+                }
+            }
+            CMSampleBufferInvalidate(sampleBuffer)
+        }
+
+        if reader.status == .failed {
+            throw TranscriptionFailure.unsupportedAudio("\(url.lastPathComponent) failed while decoding (\(reader.error?.localizedDescription ?? "unknown error"))")
+        }
+        guard let writer else {
+            throw TranscriptionFailure.unsupportedAudio("\(url.lastPathComponent) produced no decodable audio")
+        }
+        if let writeFailure {
+            throw TranscriptionFailure.unsupportedAudio("\(url.lastPathComponent) could not be transcoded (\(writeFailure.localizedDescription))")
+        }
+        // An empty scratch file would transcribe to "" and be reported as silence.
+        guard writer.length > 0 else {
+            throw TranscriptionFailure.unsupportedAudio("\(url.lastPathComponent) decoded to an empty audio stream")
+        }
+
+        return destination
+    }
+
+    private static func pcmBuffer(from sampleBuffer: CMSampleBuffer, format: AVAudioFormat) -> AVAudioPCMBuffer? {
+        let frameCount = CMSampleBufferGetNumSamples(sampleBuffer)
+        guard frameCount > 0,
+              let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frameCount)) else {
+            return nil
+        }
+        buffer.frameLength = AVAudioFrameCount(frameCount)
+
+        let status = CMSampleBufferCopyPCMDataIntoAudioBufferList(
+            sampleBuffer,
+            at: 0,
+            frameCount: Int32(frameCount),
+            into: buffer.mutableAudioBufferList
+        )
+        return status == noErr ? buffer : nil
+    }
+}
+
+/// Content-addressed transcript cache.
+///
+/// Keyed on `ZAUDIODIGEST` — a 32-byte SHA-256 of the recording that Voice Memos already maintains.
+/// That survives file touches, re-syncs, and iCloud evict/restore cycles which would all
+/// spuriously invalidate an mtime check. Transcribing a four-minute memo is not cheap, so repeat
+/// reads should never pay for it twice.
+enum TranscriptCache {
+    private static var directory: URL? {
+        guard let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        let directory = base.appendingPathComponent("M3MCP/transcripts", isDirectory: true)
+        // Owner-only. The audio these transcripts come from is TCC-protected, so writing the
+        // transcribed content world-readable would hand any unprivileged local process the contents of
+        // private voice memos — including messages from third parties.
+        try? FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        // createDirectory only applies attributes when it creates the directory, so tighten an
+        // existing one (including caches written by earlier versions) as well.
+        try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+        return directory
+    }
+
+    private static func location(forDigest digest: String) -> URL? {
+        guard !digest.isEmpty else { return nil }
+        return directory?.appendingPathComponent("\(digest).txt")
+    }
+
+    static func read(digest: String?) -> String? {
+        guard let digest, let url = location(forDigest: digest) else { return nil }
+        guard let cached = try? String(contentsOf: url, encoding: .utf8), !cached.isEmpty else {
+            return nil
+        }
+        return cached
+    }
+
+    static func has(digest: String?) -> Bool {
+        read(digest: digest) != nil
+    }
+
+    static func write(_ transcript: String, digest: String?) {
+        // Never cache an empty transcript. A recording with no speech, a transcription that failed
+        // silently, and a model that was still downloading all produce "" — persisting that would
+        // pin the memo to an empty result forever, and the miss would look like a cache bug.
+        guard !transcript.isEmpty, let digest, let url = location(forDigest: digest) else { return }
+        try? transcript.write(to: url, atomically: true, encoding: .utf8)
+        // Written after the fact because `atomically` replaces the file via a temporary, which would
+        // discard permissions supplied up front.
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+}

--- a/Sources/M3MCPBridge/ToolCatalog.swift
+++ b/Sources/M3MCPBridge/ToolCatalog.swift
@@ -123,7 +123,7 @@ enum ToolCatalog {
         ),
         MCPTool(
             name: "voicememos_transcript",
-            description: "Return the transcript macOS stored inside a Voice Memos recording. Requires macOS Sequoia or later, or a transcript created by voicememos_transcribe.",
+            description: "Return a recording's transcript: the one macOS stored inside the file, or one voicememos_transcribe produced earlier. Timestamps exist only for stored transcripts.",
             schema: objectSchema(properties: [
                 "id": ["type": "string", "description": "Recording id returned by voicememos_search."],
                 "format": [
@@ -143,7 +143,7 @@ enum ToolCatalog {
         ),
         MCPTool(
             name: "voicememos_transcribe",
-            description: "Transcribe a Voice Memos recording with on-device speech recognition. Returns the stored transcript first unless prefer_stored is false. Requires Speech Recognition permission.",
+            description: "Transcribe a Voice Memos recording on device. Uses the cheapest source first: the transcript macOS stored in the recording, then an earlier cached run, then SpeechAnalyzer on macOS 26, then SFSpeechRecognizer below that. Set prefer_stored to false to force fresh recognition. Requires Speech Recognition permission.",
             schema: objectSchema(properties: [
                 "id": ["type": "string", "description": "Recording id returned by voicememos_search."],
                 "language": ["type": "string", "description": "Recognition locale, e.g. de-DE or en-US. Defaults to the system locale."],

--- a/docs/VOICE_MEMOS.md
+++ b/docs/VOICE_MEMOS.md
@@ -78,20 +78,37 @@ file, so checking whether a recording carries a transcript does not read the aud
 - `timestamped` — `[m:ss]` lines, grouped at sentence ends or every ~15 seconds
 - `json` — plain text plus a `segments_json` metadata field with `text`, `start`, and `end`
 
-## Speech Recognition
+## Transcription
 
-`voicememos_transcribe` is the fallback for recordings without a stored transcript, for example on
-macOS Sequoia when the memo was never opened in Voice Memos. It runs `SFSpeechRecognizer` inside
-M3MCPApp, so macOS attributes the Speech Recognition permission to the signed app bundle rather than
-to the MCP bridge process.
+A memo recorded on iPhone and synced through iCloud arrives on the Mac with no transcript at all, so
+reading the `tsrp` atom is not enough. `voicememos_transcribe` works through four sources, cheapest
+first:
 
-- On-device recognition is requested whenever the locale supports it, so audio stays on the Mac.
+1. **The stored transcript** in the recording — free, no recognition run, works on macOS 15.
+2. **An earlier cached run**, keyed on `ZAUDIODIGEST`, the SHA-256 Voice Memos already maintains.
+   Keying on the digest rather than a modification date means the cache survives file touches and
+   iCloud evict/restore cycles. Empty transcripts are never cached, so a recording with no speech is
+   not pinned to an empty result forever.
+3. **`SpeechAnalyzer` / `SpeechTranscriber`** on macOS 26 — the same engine Voice Memos uses for its
+   own transcripts. First use of a locale downloads its model. Recordings that `AVAudioFile` cannot
+   open directly, such as edited `.qta` files, are transcoded through `AVAssetReader` first.
+4. **`SFSpeechRecognizer`** below macOS 26, so transcription still works on macOS 15 to 25. Bounded
+   by `timeout_seconds` (default 300); the task is cancelled when it expires.
+
+Everything runs inside M3MCPApp, so macOS attributes the Speech Recognition permission to the signed
+app bundle rather than to the MCP bridge process, and recognition stays on device.
+
 - The locale defaults to the system locale. Pass `language` (for example `de-DE`) to override it.
-- Recognition is bounded by `timeout_seconds` (default 300) and the task is cancelled on timeout.
-- An existing macOS transcript is returned first. Pass `prefer_stored: false` to force recognition.
+- Pass `prefer_stored: false` to skip steps 1 and 2 and force fresh recognition.
+- Missing language packs surface as a clear error. Install them under
+  System Settings > Accessibility > Voice Control.
 
-Missing language packs surface as a clear error. Install them under
-System Settings > Accessibility > Voice Control.
+Steps 3 and 4 write their result to the cache, so `voicememos_transcript` can return it afterwards —
+without timestamps, which only stored transcripts carry.
+
+The macOS 26 engine, the digest cache, and the `.qta` fallback come from
+[PR #1](https://github.com/GodModeAI2025/AppleMCP/pull/1) by
+[@aheusingfeld](https://github.com/aheusingfeld).
 
 ## Permissions
 


### PR DESCRIPTION
Ports the transcription engine from [PR #1](https://github.com/GodModeAI2025/AppleMCP/pull/1) into the merged provider, cherry-picked so @aheusingfeld stays the author of his file.

## Why this is needed

The `tsrp` fast path only helps when macOS has already transcribed a recording on the Mac. A memo recorded on iPhone and synced through iCloud arrives with no transcript at all — the case PR #1 was built for. Confirmed from both sides now: @GodModeAI2025's library does carry stored transcripts (`has_transcript` true, `preview` populated), and @aheusingfeld's iPhone-synced memos carry none. The two approaches are complementary, so `voicememos_transcribe` now works through four sources, cheapest first:

1. **Stored transcript** in the recording — free, no recognition run, works on macOS 15
2. **Cached earlier run**, keyed on `ZAUDIODIGEST` — the SHA-256 Voice Memos already maintains, so the cache survives file touches and iCloud evict/restore cycles
3. **`SpeechAnalyzer` / `SpeechTranscriber`** on macOS 26 — the same engine Voice Memos uses, with the `.qta` transcode fallback through `AVAssetReader`
4. **`SFSpeechRecognizer`** below that, so macOS 15 to 25 still transcribe

Steps 3 and 4 write to the cache, so `voicememos_transcript` can serve the result afterwards — without timestamps, which only stored transcripts carry. If the macOS 26 engine reports a missing model for a locale, the older recognizer still gets a turn rather than the call failing outright.

## Changes

- `SpeechTranscription.swift` from PR #1 (`e12fa16`, hardened in `b92dba6`): SpeechAnalyzer, the digest-keyed `TranscriptCache`, the `.qta` transcode
- My `SpeechTranscriber` enum is renamed to `LegacySpeechRecognizer` — macOS 26 ships `Speech.SpeechTranscriber`, and a module-level enum of the same name would have shadowed exactly the type the new path needs
- The provider reads `ZAUDIODIGEST` as the cache key, `has_transcript` now accounts for cached transcripts, and `source_status` reports the engine's availability rather than a static "on-demand"

## Not verified

Written on Linux without a Swift toolchain: no `swift build`, no `swift test`. The cascade needs macOS to exercise, and step 3 needs macOS 26 specifically. @aheusingfeld verified the engine itself on real hardware in PR #1 — what is unproven here is my wiring around it, particularly the digest read and the fallback ordering.

With this, PR #1 can be closed: everything from it is now in `main` or in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8ULNtX7RXMQoHs51ap4cg

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8ULNtX7RXMQoHs51ap4cg)_