### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+## 0.2.0
+
+### Breaking
+
+- **The local endpoint moved from `127.0.0.1:47651` to a Unix domain socket** at
+  `~/Library/Application Support/M3MCP/mcp.sock`. MCP client configuration is unaffected — clients
+  launch the bridge, and only the bridge knows the transport — but **the app and the bridge must be
+  rebuilt together**. A 0.1.0 bridge cannot reach a 0.2.0 app. Anything that called the TCP port
+  directly now uses:
+
+  ```bash
+  curl --unix-socket ~/Library/Application\ Support/M3MCP/mcp.sock http://localhost/health
+  ```
+
+- `StatusResponse` reports `endpoint` (the socket path) in place of `port`.
+
+### Added
+
+- **Voice Memos** as a data source: `voicememos_search`, `voicememos_read`, `voicememos_transcript`,
+  `voicememos_audio`, `voicememos_transcribe`. Reads the local `CloudRecordings.db` and the
+  transcripts macOS stores inside the recordings themselves.
+- **Transcription cascade** for recordings without a stored transcript — a memo recorded on iPhone
+  arrives with none: cached earlier run (keyed on `ZAUDIODIGEST`), then `SpeechAnalyzer` on
+  macOS 26, then `SFSpeechRecognizer` on macOS 15 to 25.
+- **`ai_summarize`** over the on-device foundation model: summaries and action items without a
+  Shortcut. Transcript text is fenced as data so instructions inside a recording are not followed.
+- Parser tests under `Tests/M3MCPCoreTests`, runnable with `swift test`.
+
+### Security
+
+- The endpoint is no longer reachable by other local processes. The app holds Full Disk Access, so
+  anything that reached the old TCP port borrowed that privilege — including sandboxed apps that
+  macOS specifically prevents from reading the underlying data. Access control is now filesystem
+  permissions: `0700` directory, `0600` socket.
+- Browser-originated and DNS-rebound requests are rejected (kept as defence in depth).
+
+### Fixed
+
+- Voice Memos results no longer miss the newest recordings. `CloudRecordings.db` runs in WAL mode,
+  and a read-only open cannot replay the log; reads now go through a snapshot of the store plus its
+  `-wal`/`-shm` sidecars.
+- Deleted memos are no longer listed as current ones — `ZEVICTIONDATE` is the deletion timestamp,
+  not an iCloud eviction marker. Placeholder rows with an empty `ZPATH` are filtered out.
+- Writing Tools and Translate report a missing Shortcut as a failure instead of `ok: true` carrying
+  the error text as its result.
+- The bridge no longer reports the app as unreachable while it is still working; its socket timeout
+  is 600s.
+
+### Credits
+
+Voice Memos support began as a Swift port of
+[jwulff/apple-voice-memo-mcp](https://github.com/jwulff/apple-voice-memo-mcp) (MIT). The macOS 26
+transcription engine, the digest-keyed cache, `ai_summarize`, the Shortcut fix, and the store
+findings come from [@aheusingfeld](https://github.com/aheusingfeld) via
+[PR #1](https://github.com/GodModeAI2025/AppleMCP/pull/1).
+
+## 0.1.0
+
+Initial release: Mail, Calendar, Contacts, Reminders, Notes, Photos, and Apple Intelligence tools
+over a local HTTP endpoint with an MCP `stdio` bridge.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Because the app holds Full Disk Access, anything that can reach the endpoint inh
 - Swift 5.9+
 - Apple Intelligence features require macOS 15.4+ with Apple Silicon
 
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md). Note for 0.1.0 users: the endpoint moved to a Unix domain socket, so the app and the bridge have to be rebuilt together.
+
 ## Credits
 
 The Voice Memos support is a native Swift port of [jwulff/apple-voice-memo-mcp](https://github.com/jwulff/apple-voice-memo-mcp) (MIT). See [docs/THIRD_PARTY.md](docs/THIRD_PARTY.md).

--- a/Sources/M3MCPCore/CoreModels.swift
+++ b/Sources/M3MCPCore/CoreModels.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public let m3mcpVersion = "0.1.0"
+public let m3mcpVersion = "0.2.0"
 
 public enum JSONValue: Codable, Equatable, Sendable {
     case string(String)

--- a/index.html
+++ b/index.html
@@ -202,6 +202,10 @@
                     <h3>Image Playground</h3>
                     <p>Generate images from text via the native ImagePlayground API. No app launch, pure API.</p>
                 </div>
+                <div class="card">
+                    <h3>On-Device Summaries</h3>
+                    <p>Summarize text and extract action items with the Apple Intelligence language model. Runs locally, needs no Shortcut, pairs with voice-memo transcripts. macOS 26.</p>
+                </div>
             </div>
         </section>
 
@@ -217,13 +221,15 @@
         |
    M3MCPApp (SwiftUI, holds TCC permissions)
         |
-   EventKit / Contacts / Photos / Mail Index / Voice Memos Store / Speech / AppleScript</div>
+   EventKit / Contacts / Photos / Mail Index / Voice Memos Store
+   Speech / FoundationModels / AppleScript</div>
         </section>
 
         <section>
             <h2>Setup</h2>
 <pre><code># Build
 swift build
+swift test
 
 # Run the app
 ./script/build_and_run.sh
@@ -238,7 +244,11 @@ swift build
 }
 
 # Or add to Claude Code
-claude mcp add applemcp /path/to/AppleMCP/.build/debug/M3MCPBridge</code></pre>
+claude mcp add applemcp /path/to/AppleMCP/.build/debug/M3MCPBridge
+
+# Check the endpoint
+curl --unix-socket ~/Library/Application\ Support/M3MCP/mcp.sock \
+  http://localhost/health</code></pre>
         </section>
 
         <div class="cta">
@@ -246,7 +256,7 @@ claude mcp add applemcp /path/to/AppleMCP/.build/debug/M3MCPBridge</code></pre>
         </div>
 
         <footer>
-            <p>AppleMCP is open source under the MIT license. All data stays on your device.</p>
+            <p>AppleMCP is open source under the Apache 2.0 license. All data stays on your device.</p>
             <p style="margin-top: 8px;"><a href="https://godmodeai2025.github.io/MarkZimmermann/" style="color: var(--muted); text-decoration: none;">Impressum</a></p>
         </footer>
     </div>


### PR DESCRIPTION
Closes out the Voice Memos, socket, and Apple Intelligence work with a version bump, a changelog, and the documentation gaps the last three merges left behind.

## Changes

- `m3mcpVersion` 0.1.0 → 0.2.0
- `CHANGELOG.md`, leading with the breaking change: a 0.1.0 bridge cannot reach a 0.2.0 app, since the endpoint moved from `127.0.0.1:47651` to a Unix domain socket. MCP client configuration is unaffected — clients launch the bridge, and only the bridge knows the transport — but both binaries have to be rebuilt together.
- Landing page: adds the on-device summaries card, drops the TCP port from the architecture sketch, adds the socket health check to the setup snippet, and corrects "MIT license" to Apache 2.0 to match `LICENSE` (the README carried the same error and was fixed earlier).
- README links the changelog.

## Why 0.2.0 and not 0.1.1

The transport changed, `StatusResponse` reports `endpoint` in place of `port`, and six tools were added. That is a minor bump under semver even pre-1.0, and the changelog needs to be somewhere a 0.1.0 user will look before wondering why the bridge stopped connecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8ULNtX7RXMQoHs51ap4cg

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8ULNtX7RXMQoHs51ap4cg)_