### PR TITLE
fix(script): create_local_identity.sh aborts on bash 3.2 (stock macOS shell)

### DIFF
--- a/script/create_local_identity.sh
+++ b/script/create_local_identity.sh
@@ -61,7 +61,10 @@ if [[ -n "${M3MCP_ALLOW_CODESIGN_NOPROMPT:-}" ]]; then
   IMPORT_ARGS+=(-T /usr/bin/codesign)
 fi
 
-security import "$WORK_DIR/identity.p12" -k "$KEYCHAIN" -P "$PASSWORD" "${IMPORT_ARGS[@]}" >/dev/null
+# bash 3.2 — the shell macOS actually ships — treats "${arr[@]}" as an unbound variable under
+# `set -u` when the array is empty, so the default path (no extra args) aborted here. The
+# ${arr[@]+...} guard expands to nothing when unset and is portable back to 3.2.
+security import "$WORK_DIR/identity.p12" -k "$KEYCHAIN" -P "$PASSWORD" ${IMPORT_ARGS[@]+"${IMPORT_ARGS[@]}"} >/dev/null
 
 if security find-identity -p codesigning 2>/dev/null | grep -qF "$IDENTITY_NAME"; then
   echo "Created '$IDENTITY_NAME'."


### PR DESCRIPTION
`script/create_local_identity.sh` cannot complete on a stock macOS shell.

Line 64 passes `"${IMPORT_ARGS[@]}"` to `security import`. Under `set -u`, **bash 3.2 treats the expansion of an empty array as an unbound variable** and aborts — and the array is empty on the *documented default path*, where `M3MCP_ALLOW_CODESIGN_NOPROMPT` is deliberately unset:

```
$ ./script/create_local_identity.sh
Generating a self-signed code-signing certificate…
./script/create_local_identity.sh: line 64: IMPORT_ARGS[@]: unbound variable
```

bash 4.4+ expands it fine, so this reproduces only where it matters most: macOS ships bash 3.2. Verified on this machine — both `/bin/bash` and `bash` on `PATH` report `3.2.57(1)-release (arm64-apple-darwin25)`.

The `${arr[@]+"${arr[@]}"}` form expands to nothing when the array is unset or empty and is portable back to 3.2. With the fix the script runs to completion and creates the identity — which is the thing that makes Full Disk Access survive rebuilds, so the failure blocks the whole documented local-install path.

Tested by running the script on this machine before and after: before, aborts as above with no identity created; after, `security find-identity -p codesigning` lists `M3MCP Local Development`, and `install_local.sh` then signs the bundle with a certificate-based designated requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)