### PR TITLE
CI sichtbar machen und Aussagen richtigstellen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  swift:
+    name: Build and tests
+    # macos-26, not macos-14 or macos-15: Package.swift weak-links FoundationModels
+    # unconditionally, and that framework only exists in the macOS 26 SDK. On an older SDK
+    # the link step fails with "ld: framework 'FoundationModels' not found". macos-14 is
+    # also deprecated in actions/runner-images.
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: SDK carries FoundationModels
+        run: |
+          set -euo pipefail
+          swift --version
+          sdk="$(xcrun --show-sdk-path)"
+          echo "SDK: $sdk"
+          if [ ! -d "$sdk/System/Library/Frameworks/FoundationModels.framework" ]; then
+            echo "::error::This SDK has no FoundationModels. Package.swift passes -weak_framework FoundationModels, so the link step would fail. Use a runner image whose default Xcode ships the macOS 26 SDK." >&2
+            exit 1
+          fi
+
+      - name: swift build
+        run: swift build
+
+      - name: swift test
+        run: swift test
+
+      # install_local.sh, the documented install path, builds with -c release. Release uses
+      # whole-module optimization, so it catches what a debug build lets through.
+      - name: swift build -c release
+        run: swift build -c release
+
+  docs:
+    name: Docs against code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: README and landing page match the code
+        run: python3 script/check_docs.py

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![CI](https://github.com/GodModeAI2025/AppleMCP/actions/workflows/ci.yml/badge.svg)](https://github.com/GodModeAI2025/AppleMCP/actions/workflows/ci.yml)
 
-Native macOS 15+ MCP server that gives AI assistants local access to your Apple data and Apple Intelligence features. Most tools read. Writing happens in three places: five calendar tools change your calendars, `ai_image_playground` writes a PNG per call, and `voicememos_transcribe` stores every transcript it produces under `~/Library/Application Support/M3MCP/transcripts/`.
+Native macOS 15+ MCP server that gives AI assistants local access to your Apple data and Apple Intelligence features. Most tools read. Those that write include five calendar tools that change your calendars, `ai_image_playground`, which writes a PNG per call, and `voicememos_transcribe`, which keeps the transcripts it produces under `~/Library/Application Support/M3MCP/transcripts/` and leaves a scratch audio file in the temporary directory whenever a recording has to be transcoded before recognition.
 
-AppleMCP consists of a SwiftUI app that bridges macOS privacy-controlled APIs and a `stdio` MCP server for Claude Desktop, Claude Code, and other MCP clients. It runs locally, with no cloud account and no sync of its own. Two things cross that line: `ai_translate` and `ai_writing_tools` hand your text to a Shortcut you built yourself, and `voicememos_transcribe` lets Apple's speech service take the audio when the locale has no on-device model. See [Limits](#limits).
+AppleMCP consists of a SwiftUI app that bridges macOS privacy-controlled APIs and a `stdio` MCP server for Claude Desktop, Claude Code, and other MCP clients. It runs locally, with no cloud account and no sync of its own. That does not make every path local: `ai_translate` and `ai_writing_tools` hand your text to a Shortcut you built yourself, `voicememos_transcribe` lets Apple's speech service take the audio when the locale has no on-device model, and an event a calendar tool writes into an iCloud calendar syncs like any other. See [Limits](#limits).
 
 ## What It Does
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![CI](https://github.com/GodModeAI2025/AppleMCP/actions/workflows/ci.yml/badge.svg)](https://github.com/GodModeAI2025/AppleMCP/actions/workflows/ci.yml)
 
-Native macOS 15+ MCP server that gives AI assistants local access to your Apple data and Apple Intelligence features. Most tools read. Five calendar tools write to your calendars, and `ai_image_playground` writes PNG files to disk.
+Native macOS 15+ MCP server that gives AI assistants local access to your Apple data and Apple Intelligence features. Most tools read. Writing happens in three places: five calendar tools change your calendars, `ai_image_playground` writes a PNG per call, and `voicememos_transcribe` stores every transcript it produces under `~/Library/Application Support/M3MCP/transcripts/`.
 
-AppleMCP consists of a SwiftUI app that bridges macOS privacy-controlled APIs and a `stdio` MCP server for Claude Desktop, Claude Code, and other MCP clients. Everything runs locally: no cloud, no sync, no data leaves your machine.
+AppleMCP consists of a SwiftUI app that bridges macOS privacy-controlled APIs and a `stdio` MCP server for Claude Desktop, Claude Code, and other MCP clients. It runs locally, with no cloud account and no sync of its own. Two things cross that line: `ai_translate` and `ai_writing_tools` hand your text to a Shortcut you built yourself, and `voicememos_transcribe` lets Apple's speech service take the audio when the locale has no on-device model. See [Limits](#limits).
 
 ## What It Does
 
@@ -17,7 +17,7 @@ AppleMCP consists of a SwiftUI app that bridges macOS privacy-controlled APIs an
 | **Notes** | Notes.app AppleScript Automation | Automation Permission |
 | **Photos** | Photos.framework | Photos Access |
 | **Voice Memos** | Local `CloudRecordings.db` + in-file transcripts, SpeechAnalyzer / SFSpeechRecognizer for recordings without one | Full Disk Access, Speech Recognition (only for `voicememos_transcribe`) |
-| **Apple Intelligence** | Native APIs (ImagePlayground, Translation, Writing Tools) | None |
+| **Apple Intelligence** | ImagePlayground framework for images; `shortcuts run` through AppleScript for Translation and Writing Tools | None |
 | **Foundation Models** | On-device language model via FoundationModels (macOS 26, weak-linked) | None |
 
 ## What AppleMCP Is Not
@@ -97,7 +97,7 @@ The M3MCP UI app must be running for MCP calls to work. The bridge talks to the 
 
 | Tool | Description |
 |---|---|
-| `mail_search` | Search messages in Apple Mail (subject, sender, date, read status) |
+| `mail_search` | Search messages in the local Apple Mail index. Matches subject, sender and recipients by default, body on request; scoped to a mailbox with `mailbox`, narrowed with `unread_only` and `since_hours`, paged with `offset`, and `match` picks how a multi-word query applies: all, any, or phrase |
 | `mail_list_mailboxes` | List the mailboxes of the local Mail index with account, path, role, and message counts, so a `mail_search` can be scoped to a name that exists |
 | `mail_read` | Read full email content by ID (body, recipients, attachments metadata) |
 | `calendar_search` | Search calendar events via EventKit, optionally scoped to one calendar |
@@ -113,7 +113,7 @@ The M3MCP UI app must be running for MCP calls to work. The bridge talks to the 
 | `voicememos_read` | Read one recording including its stored transcript |
 | `voicememos_transcript` | Return a stored transcript as text, timestamped text, or JSON segments |
 | `voicememos_audio` | Return the recording as a local path or base64 audio |
-| `voicememos_transcribe` | Transcribe on device: stored transcript, cache, SpeechAnalyzer (macOS 26), then SFSpeechRecognizer |
+| `voicememos_transcribe` | Transcribe a recording: stored transcript, cache, SpeechAnalyzer (macOS 26), then SFSpeechRecognizer, which is on device only where the locale has a model |
 
 ### Calendar Writes
 
@@ -170,9 +170,9 @@ See [docs/VOICE_MEMOS.md](docs/VOICE_MEMOS.md) for the store layout, the transcr
 
 ## Privacy
 
-All data stays local. The app uses macOS TCC (Transparency, Consent, and Control) for every data source. AppleMCP opens no remote connection: the endpoint is a Unix domain socket rather than a TCP port, and the HTTP the bridge speaks travels only over that socket.
+What the app reads stays on the Mac, except where a tool hands it on: `ai_translate` and `ai_writing_tools` to a Shortcut you built, `voicememos_transcribe` to Apple's speech service on locales without an on-device model, see [Limits](#limits). The app uses macOS TCC (Transparency, Consent, and Control) for every data source. AppleMCP opens no remote connection: the endpoint is a Unix domain socket rather than a TCP port, and the HTTP the bridge speaks travels only over that socket.
 
-Because the app holds Full Disk Access, anything that can reach the endpoint inherits that reach. The socket lives in a `0700` directory and is itself `0600`, so a sandboxed app — the case macOS TCC exists to stop — cannot connect, and a web page cannot reach it under any circumstances. An unsandboxed process running as you is a different case, see [Limits](#limits). Mail reads the local SQLite index directly, it never sends emails or modifies any data. Voice Memos are opened read-only, and speech recognition runs on device whenever the locale supports it, so recordings never leave the Mac.
+Because the app holds Full Disk Access, anything that can reach the endpoint inherits that reach. The socket lives in a `0700` directory and is itself `0600`, so a sandboxed app — the case macOS TCC exists to stop — cannot connect, and a web page cannot reach it under any circumstances. An unsandboxed process running as you is a different case, see [Limits](#limits). Mail reads the local SQLite index directly, it never sends emails or modifies any data. Voice Memos are opened read-only. Speech recognition runs on device where the locale has a model for it; where it does not, the audio goes to Apple's speech service instead.
 
 ## Security
 
@@ -182,8 +182,9 @@ The security policy and the threat model live in `SECURITY.md`, currently in rev
 
 - **The socket does not check who connects.** File permissions keep out sandboxed apps and web pages. They do not distinguish one unsandboxed process of yours from another, so any local process running as you can call the endpoint and use the app's Full Disk Access. Tracked as [issue #9](https://github.com/GodModeAI2025/AppleMCP/issues/9).
 - **`ai_translate` has prerequisites nothing sets up for you.** The provider pipes the text through `/usr/bin/python3` into `shortcuts run Translate`. You need a Shortcut named "Translate" that you created yourself, and the system Python 3 at `/usr/bin/python3`. Without either the tool answers that translation is not reachable. Whether the translation itself stays on the Mac depends on whether the language pair is downloaded, which the Shortcuts and Translate apps decide, not AppleMCP.
-- **`ai_writing_tools` needs a Shortcut named "Writing Tools"** for the same reason. `ai_summarize` does not; it calls FoundationModels directly and needs macOS 26.
+- **`ai_writing_tools` needs a Shortcut named "Writing Tools"** for the same reason, and the same open question follows: the text goes into that Shortcut, and where it goes from there is the Shortcut's business, not AppleMCP's. `ai_summarize` does not; it calls FoundationModels directly and needs macOS 26.
 - **`ai_image_playground` leaves files behind.** Each call writes a PNG into the process temporary directory and returns the path. AppleMCP never deletes them; they stay until macOS clears that directory.
+- **`voicememos_transcribe` keeps what it recognizes.** Every recognition run writes the text to `~/Library/Application Support/M3MCP/transcripts/<digest>.txt`, mode `0600` in a `0700` directory, which is what makes the second call for the same recording cheap. Nothing deletes those files afterwards, and unlike the PNG files they do not sit in a directory macOS clears. Recognition is only on device where the locale has a model: `LegacySpeechRecognizer` sets `requiresOnDeviceRecognition` to whatever `SFSpeechRecognizer` reports as supported (line 72), so on every other locale the audio goes to Apple.
 - **Calendar writes cannot be undone.** `calendar_delete_calendar` removes a calendar with its events. It refuses unless `id` and `title` agree and the calendar is mutable, and that is the whole safety net: there is no dry-run mode and no confirmation step.
 - **Test coverage is narrow.** The suite covers the Voice Memos transcript parser and the calendar project slug. Providers, the local HTTP server, and the bridge have no tests, so CI proves that the package builds and those two units work, not that a provider still returns what it used to.
 - **Building needs the macOS 26 SDK.** `Package.swift` weak-links `FoundationModels`, which exists only in that SDK. Without it the link step fails with `ld: framework 'FoundationModels' not found`, even though the built app runs on macOS 15.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # AppleMCP
 
-Native macOS 15+ MCP server that gives AI assistants secure, read-only access to your local Apple data and Apple Intelligence features.
+[![CI](https://github.com/GodModeAI2025/AppleMCP/actions/workflows/ci.yml/badge.svg)](https://github.com/GodModeAI2025/AppleMCP/actions/workflows/ci.yml)
 
-AppleMCP consists of a SwiftUI app that bridges macOS privacy-controlled APIs and a `stdio` MCP server for Claude Desktop, Claude Code, and other MCP clients. Everything runs locally — no cloud, no sync, no data leaves your machine.
+Native macOS 15+ MCP server that gives AI assistants local access to your Apple data and Apple Intelligence features. Most tools read. Five calendar tools write to your calendars, and `ai_image_playground` writes PNG files to disk.
+
+AppleMCP consists of a SwiftUI app that bridges macOS privacy-controlled APIs and a `stdio` MCP server for Claude Desktop, Claude Code, and other MCP clients. Everything runs locally: no cloud, no sync, no data leaves your machine.
 
 ## What It Does
 
 | Source | Access Method | Permission |
 |---|---|---|
 | **Mail** | Local Envelope Index (SQLite) + `.emlx` body parsing, AppleScript fallback | Full Disk Access or Mail Automation |
-| **Calendar** | EventKit | Calendar Access |
+| **Calendar** | EventKit, read and write | Calendar Access |
 | **Contacts** | Contacts.framework | Contacts Access |
 | **Reminders** | EventKit | Reminders Access |
 | **Notes** | Notes.app AppleScript Automation | Automation Permission |
@@ -18,22 +20,40 @@ AppleMCP consists of a SwiftUI app that bridges macOS privacy-controlled APIs an
 | **Apple Intelligence** | Native APIs (ImagePlayground, Translation, Writing Tools) | None |
 | **Foundation Models** | On-device language model via FoundationModels (macOS 26, weak-linked) | None |
 
+## What AppleMCP Is Not
+
+- **No GUI automation.** It never clicks, types, or drives an app through its interface. Notes is reached through AppleScript, which is scripting, not the UI.
+- **No screenshots, no screen recording.** Nothing reads the display.
+- **No computer use.** There is no loop in which a model looks at the screen and acts on it.
+- **No mail sending.** The Mail tools read the local index and the `.emlx` files. They compose nothing and send nothing.
+- **No network listener.** The endpoint is a Unix domain socket, not a TCP port, and the sources contain no HTTP client.
+
 ## Quick Start
 
 ### 1. Build
 
 ```bash
-swift build
-swift test   # parser tests for the Voice Memos transcript format
+swift build -c release
+swift test
 ```
 
+Release, not debug, because `script/install_local.sh` builds `-c release` and the MCP client config below points into `.build/release`. `script/build_and_run.sh` builds the debug configuration for a one-off run and does not produce that binary.
+
 ### 2. Run the App
+
+For a persistent install under launchd, with a stable signature so the Full Disk Access grant survives rebuilds:
+
+```bash
+./script/install_local.sh
+```
+
+For a one-off run from the terminal:
 
 ```bash
 ./script/build_and_run.sh
 ```
 
-The app opens a macOS window and starts a local endpoint on a Unix domain socket at `~/Library/Application Support/M3MCP/mcp.sock`. Click **Permissions** on first launch to grant macOS access to Calendar, Contacts, Reminders, Photos, and Notes.
+Either way the app starts a local endpoint on a Unix domain socket at `~/Library/Application Support/M3MCP/mcp.sock`. Click **Permissions** on first launch to grant macOS access to Calendar, Contacts, Reminders, Photos, and Notes.
 
 Check that it is up:
 
@@ -51,7 +71,7 @@ Add to your Claude Desktop MCP config (`~/Library/Application Support/Claude/cla
 {
   "mcpServers": {
     "applemcp": {
-      "command": "/path/to/AppleMCP/.build/debug/M3MCPBridge"
+      "command": "/path/to/AppleMCP/.build/release/M3MCPBridge"
     }
   }
 }
@@ -60,7 +80,7 @@ Add to your Claude Desktop MCP config (`~/Library/Application Support/Claude/cla
 #### Claude Code
 
 ```bash
-claude mcp add applemcp /path/to/AppleMCP/.build/debug/M3MCPBridge
+claude mcp add applemcp /path/to/AppleMCP/.build/release/M3MCPBridge
 ```
 
 The M3MCP UI app must be running for MCP calls to work. The bridge talks to the app over a Unix domain socket in the user's Application Support directory.
@@ -72,9 +92,10 @@ The M3MCP UI app must be running for MCP calls to work. The bridge talks to the 
 | Tool | Description |
 |---|---|
 | `mail_search` | Search messages in Apple Mail (subject, sender, date, read status) |
+| `mail_list_mailboxes` | List the mailboxes of the local Mail index, to scope a search |
 | `mail_read` | Read full email content by ID (body, recipients, attachments metadata) |
 | `calendar_search` | Search calendar events via EventKit, optionally scoped to one calendar |
-| `calendar_read_event` | Read one event by ID — use this to confirm a write, since `calendar_search` only scans a date window |
+| `calendar_read_event` | Read one event by ID, the way to confirm a write, since `calendar_search` only scans a date window |
 | `calendar_list_calendars` | List calendars with their source, ID, and whether they are writable |
 | `contacts_search` | Search contacts / address book |
 | `reminders_search` | Search reminders (incomplete, completed, or all) |
@@ -104,10 +125,10 @@ These change the user's calendar. There is no undo.
 
 | Tool | Description |
 |---|---|
-| `ai_summarize` | Summarize text and extract action items with the on-device foundation model (macOS 26) |
-| `ai_writing_tools` | Summarize, rewrite, proofread, or change tone of text (needs a "Writing Tools" Shortcut) |
-| `ai_translate` | Translate text using Apple system translation |
-| `ai_image_playground` | Generate images from text descriptions (macOS 15.4+) |
+| `ai_summarize` | Summarize text and extract action items with the on-device foundation model (macOS 26). Needs no Shortcut |
+| `ai_writing_tools` | Summarize, rewrite, proofread, or change tone of text. Needs a Shortcut named "Writing Tools", see [Limits](#limits) |
+| `ai_translate` | Translate text using Apple system translation. Needs a Shortcut named "Translate" and `/usr/bin/python3`, see [Limits](#limits) |
+| `ai_image_playground` | Generate images from text descriptions (macOS 15.4+). Writes a PNG file and returns its path |
 
 ### System
 
@@ -143,14 +164,42 @@ See [docs/VOICE_MEMOS.md](docs/VOICE_MEMOS.md) for the store layout, the transcr
 
 ## Privacy
 
-All data stays local. The app uses macOS TCC (Transparency, Consent, and Control) for every data source. No network requests are made at all: the endpoint is a Unix domain socket, not a TCP port.
+All data stays local. The app uses macOS TCC (Transparency, Consent, and Control) for every data source. AppleMCP itself makes no network requests: the endpoint is a Unix domain socket, not a TCP port, and the sources contain no HTTP client.
 
-Because the app holds Full Disk Access, anything that can reach the endpoint inherits that reach. The socket lives in a `0700` directory and is itself `0600`, so a sandboxed app — the case macOS TCC exists to stop — cannot connect, and a web page cannot reach it under any circumstances. Mail reads the local SQLite index directly — it never sends emails or modifies any data. Voice Memos are opened read-only, and speech recognition runs on device whenever the locale supports it, so recordings never leave the Mac.
+Because the app holds Full Disk Access, anything that can reach the endpoint inherits that reach. The socket lives in a `0700` directory and is itself `0600`, so a sandboxed app — the case macOS TCC exists to stop — cannot connect, and a web page cannot reach it under any circumstances. An unsandboxed process running as you is a different case, see [Limits](#limits). Mail reads the local SQLite index directly, it never sends emails or modifies any data. Voice Memos are opened read-only, and speech recognition runs on device whenever the locale supports it, so recordings never leave the Mac.
+
+## Security
+
+The security policy and the threat model live in `SECURITY.md`, currently in review as [PR #14](https://github.com/GodModeAI2025/AppleMCP/pull/14). They are not repeated here, so there is one place to correct when the architecture moves.
+
+## Limits
+
+- **The socket does not check who connects.** File permissions keep out sandboxed apps and web pages. They do not distinguish one unsandboxed process of yours from another, so any local process running as you can call the endpoint and use the app's Full Disk Access. Tracked as [issue #9](https://github.com/GodModeAI2025/AppleMCP/issues/9).
+- **`ai_translate` has prerequisites nothing sets up for you.** The provider pipes the text through `/usr/bin/python3` into `shortcuts run Translate`. You need a Shortcut named "Translate" that you created yourself, and the system Python 3 at `/usr/bin/python3`. Without either the tool answers that translation is not reachable. Whether the translation itself stays on the Mac depends on whether the language pair is downloaded, which the Shortcuts and Translate apps decide, not AppleMCP.
+- **`ai_writing_tools` needs a Shortcut named "Writing Tools"** for the same reason. `ai_summarize` does not; it calls FoundationModels directly and needs macOS 26.
+- **`ai_image_playground` leaves files behind.** Each call writes a PNG into the process temporary directory and returns the path. Nothing deletes them.
+- **Calendar writes cannot be undone.** `calendar_delete_calendar` removes a calendar with its events; the only guard is that `id` and `title` have to agree. There is no dry-run mode and no confirmation step.
+- **Test coverage is narrow.** The suite covers the Voice Memos transcript parser and the calendar project slug. Providers, the local HTTP server, and the bridge have no tests, so CI proves that the package builds and those two units work, not that a provider still returns what it used to.
+- **Building needs the macOS 26 SDK.** `Package.swift` weak-links `FoundationModels`, which exists only in that SDK, so Xcode 26 or later is required to link even though the app runs on macOS 15.
+
+## Roadmap
+
+Tracked in the issue tracker:
+
+- Verify the connecting process on the socket, so an unsandboxed local process cannot borrow the app's Full Disk Access ([issue #9](https://github.com/GodModeAI2025/AppleMCP/issues/9))
+- Bring the threat model into the repo, updated for the current architecture ([issue #10](https://github.com/GodModeAI2025/AppleMCP/issues/10), in review as [PR #14](https://github.com/GodModeAI2025/AppleMCP/pull/14))
+
+Wanted, no issue open yet:
+
+- A safety layer for the write tools: dry-run, and a confirmation for the destructive ones
+- Tests for the providers and the bridge, so CI covers more than the parser
+- A tagged release with a signed build, instead of the source build as the only path
 
 ## Requirements
 
-- macOS 15.0+
-- Swift 5.9+
+- macOS 15.0+ to run
+- Xcode 26 or later to build, because of the weak-linked `FoundationModels`
+- Swift 5.9+ tools version
 - Apple Intelligence features require macOS 15.4+ with Apple Silicon
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ AppleMCP consists of a SwiftUI app that bridges macOS privacy-controlled APIs an
 - **No screenshots, no screen recording.** Nothing reads the display.
 - **No computer use.** There is no loop in which a model looks at the screen and acts on it.
 - **No mail sending.** The Mail tools read the local index and the `.emlx` files. They compose nothing and send nothing.
-- **No network listener.** The endpoint is a Unix domain socket, not a TCP port, and the sources contain no HTTP client.
+- **No network.** The endpoint is a Unix domain socket, not a TCP port. The bridge does speak HTTP, but only across that socket. The sources open no connection to a remote host and contain no `URLSession`.
 
 ## Quick Start
 
@@ -45,6 +45,12 @@ For a persistent install under launchd, with a stable signature so the Full Disk
 
 ```bash
 ./script/install_local.sh
+```
+
+That signature has to come from somewhere. Without a usable code-signing identity the script stops with "No usable code-signing identity found", so create a local one first:
+
+```bash
+./script/create_local_identity.sh
 ```
 
 For a one-off run from the terminal:
@@ -92,7 +98,7 @@ The M3MCP UI app must be running for MCP calls to work. The bridge talks to the 
 | Tool | Description |
 |---|---|
 | `mail_search` | Search messages in Apple Mail (subject, sender, date, read status) |
-| `mail_list_mailboxes` | List the mailboxes of the local Mail index, to scope a search |
+| `mail_list_mailboxes` | List the mailboxes of the local Mail index with account, path, role, and message counts, so a `mail_search` can be scoped to a name that exists |
 | `mail_read` | Read full email content by ID (body, recipients, attachments metadata) |
 | `calendar_search` | Search calendar events via EventKit, optionally scoped to one calendar |
 | `calendar_read_event` | Read one event by ID, the way to confirm a write, since `calendar_search` only scans a date window |
@@ -164,7 +170,7 @@ See [docs/VOICE_MEMOS.md](docs/VOICE_MEMOS.md) for the store layout, the transcr
 
 ## Privacy
 
-All data stays local. The app uses macOS TCC (Transparency, Consent, and Control) for every data source. AppleMCP itself makes no network requests: the endpoint is a Unix domain socket, not a TCP port, and the sources contain no HTTP client.
+All data stays local. The app uses macOS TCC (Transparency, Consent, and Control) for every data source. AppleMCP opens no remote connection: the endpoint is a Unix domain socket rather than a TCP port, and the HTTP the bridge speaks travels only over that socket.
 
 Because the app holds Full Disk Access, anything that can reach the endpoint inherits that reach. The socket lives in a `0700` directory and is itself `0600`, so a sandboxed app — the case macOS TCC exists to stop — cannot connect, and a web page cannot reach it under any circumstances. An unsandboxed process running as you is a different case, see [Limits](#limits). Mail reads the local SQLite index directly, it never sends emails or modifies any data. Voice Memos are opened read-only, and speech recognition runs on device whenever the locale supports it, so recordings never leave the Mac.
 
@@ -177,10 +183,10 @@ The security policy and the threat model live in `SECURITY.md`, currently in rev
 - **The socket does not check who connects.** File permissions keep out sandboxed apps and web pages. They do not distinguish one unsandboxed process of yours from another, so any local process running as you can call the endpoint and use the app's Full Disk Access. Tracked as [issue #9](https://github.com/GodModeAI2025/AppleMCP/issues/9).
 - **`ai_translate` has prerequisites nothing sets up for you.** The provider pipes the text through `/usr/bin/python3` into `shortcuts run Translate`. You need a Shortcut named "Translate" that you created yourself, and the system Python 3 at `/usr/bin/python3`. Without either the tool answers that translation is not reachable. Whether the translation itself stays on the Mac depends on whether the language pair is downloaded, which the Shortcuts and Translate apps decide, not AppleMCP.
 - **`ai_writing_tools` needs a Shortcut named "Writing Tools"** for the same reason. `ai_summarize` does not; it calls FoundationModels directly and needs macOS 26.
-- **`ai_image_playground` leaves files behind.** Each call writes a PNG into the process temporary directory and returns the path. Nothing deletes them.
-- **Calendar writes cannot be undone.** `calendar_delete_calendar` removes a calendar with its events; the only guard is that `id` and `title` have to agree. There is no dry-run mode and no confirmation step.
+- **`ai_image_playground` leaves files behind.** Each call writes a PNG into the process temporary directory and returns the path. AppleMCP never deletes them; they stay until macOS clears that directory.
+- **Calendar writes cannot be undone.** `calendar_delete_calendar` removes a calendar with its events. It refuses unless `id` and `title` agree and the calendar is mutable, and that is the whole safety net: there is no dry-run mode and no confirmation step.
 - **Test coverage is narrow.** The suite covers the Voice Memos transcript parser and the calendar project slug. Providers, the local HTTP server, and the bridge have no tests, so CI proves that the package builds and those two units work, not that a provider still returns what it used to.
-- **Building needs the macOS 26 SDK.** `Package.swift` weak-links `FoundationModels`, which exists only in that SDK, so Xcode 26 or later is required to link even though the app runs on macOS 15.
+- **Building needs the macOS 26 SDK.** `Package.swift` weak-links `FoundationModels`, which exists only in that SDK. Without it the link step fails with `ld: framework 'FoundationModels' not found`, even though the built app runs on macOS 15.
 
 ## Roadmap
 
@@ -198,7 +204,7 @@ Wanted, no issue open yet:
 ## Requirements
 
 - macOS 15.0+ to run
-- Xcode 26 or later to build, because of the weak-linked `FoundationModels`
+- Xcode 26 or the matching Command Line Tools to build, for the macOS 26 SDK that carries the weak-linked `FoundationModels`
 - Swift 5.9+ tools version
 - Apple Intelligence features require macOS 15.4+ with Apple Silicon
 

--- a/Sources/M3MCPApp/Resources/Info.plist
+++ b/Sources/M3MCPApp/Resources/Info.plist
@@ -19,9 +19,9 @@
   <key>NSAppDataUsageDescription</key>
   <string>M3MCP liest den lokalen Apple-Mail-Index fuer MCP-Mail-Abfragen, ohne Mail.app per AppleScript zu durchsuchen.</string>
   <key>NSCalendarsUsageDescription</key>
-  <string>M3MCP liest lokale Kalenderdaten fuer MCP-Abfragen.</string>
+  <string>M3MCP liest lokale Kalenderdaten fuer MCP-Abfragen und legt Termine und Kalender an, aendert und loescht sie ueber die Kalender-Schreibwerkzeuge.</string>
   <key>NSCalendarsFullAccessUsageDescription</key>
-  <string>M3MCP liest lokale Kalenderdaten fuer MCP-Abfragen.</string>
+  <string>M3MCP liest lokale Kalenderdaten fuer MCP-Abfragen und legt Termine und Kalender an, aendert und loescht sie ueber die Kalender-Schreibwerkzeuge.</string>
   <key>NSContactsUsageDescription</key>
   <string>M3MCP liest lokale Kontakte fuer MCP-Abfragen.</string>
   <key>NSRemindersUsageDescription</key>

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -49,7 +49,7 @@ Relevant references:
 - Keep MCP `stdout` pure JSON-RPC. Send diagnostics to `stderr` or the app UI.
 - Expose visible tool status in the UI so the user can see what is available to the model.
 - Record invocations in the app Activity area with provider, endpoint, status, and timing.
-- Keep data-source tools read-only. Apple Intelligence tools may launch or invoke system actions, so their descriptions must be explicit.
+- Data-source tools default to reading. Where a source is written, as the five calendar tools do, say so in the tool description, name the write in the README, and keep the destructive case guarded (`calendar_delete_calendar` demands id and title together). Apple Intelligence tools may launch or invoke system actions and may write files, so their descriptions must be explicit.
 - Add permission tools (`permissions_status`, `permissions_request`, `permissions_open_settings`) so the model can explain missing access without guessing.
 
 Relevant MCP docs:

--- a/docs/VOICE_MEMOS.md
+++ b/docs/VOICE_MEMOS.md
@@ -96,7 +96,9 @@ first:
    by `timeout_seconds` (default 300); the task is cancelled when it expires.
 
 Everything runs inside M3MCPApp, so macOS attributes the Speech Recognition permission to the signed
-app bundle rather than to the MCP bridge process, and recognition stays on device.
+app bundle rather than to the MCP bridge process. Step 3 is on device by construction. Step 4 sets
+`requiresOnDeviceRecognition` to what `SFSpeechRecognizer` reports as supported, so a locale without a
+local model is recognized by Apple's speech service, not on the Mac.
 
 - The locale defaults to the system locale. Pass `language` (for example `de-DE`) to override it.
 - Pass `prefer_stored: false` to skip steps 1 and 2 and force fresh recognition.

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
                 </div>
                 <div class="card">
                     <h3>Calendar</h3>
-                    <p>Search events via EventKit. Titles, locations, times, notes, all-day status, and calendar membership.</p>
+                    <p>Search events via EventKit. Titles, locations, times, notes, all-day status, and calendar membership. Five tools also write: create, update and delete events, create and delete calendars. There is no undo.</p>
                 </div>
                 <div class="card">
                     <h3>Contacts</h3>
@@ -200,7 +200,7 @@
                 </div>
                 <div class="card">
                     <h3>Image Playground</h3>
-                    <p>Generate images from text via the native ImagePlayground API. No app launch, pure API.</p>
+                    <p>Generate images from text via the native ImagePlayground API. No app launch, pure API. Each call writes a PNG into the temporary directory and returns its path.</p>
                 </div>
                 <div class="card">
                     <h3>On-Device Summaries</h3>
@@ -227,24 +227,24 @@
 
         <section>
             <h2>Setup</h2>
-<pre><code># Build
-swift build
+<pre><code># Build (release, the configuration install_local.sh uses)
+swift build -c release
 swift test
 
-# Run the app
-./script/build_and_run.sh
+# Install and start it under launchd
+./script/install_local.sh
 
-# Add to Claude Desktop (~/.config/claude/claude_desktop_config.json)
+# Add to Claude Desktop (~/Library/Application Support/Claude/claude_desktop_config.json)
 {
   "mcpServers": {
     "applemcp": {
-      "command": "/path/to/AppleMCP/.build/debug/M3MCPBridge"
+      "command": "/path/to/AppleMCP/.build/release/M3MCPBridge"
     }
   }
 }
 
 # Or add to Claude Code
-claude mcp add applemcp /path/to/AppleMCP/.build/debug/M3MCPBridge
+claude mcp add applemcp /path/to/AppleMCP/.build/release/M3MCPBridge
 
 # Check the endpoint
 curl --unix-socket ~/Library/Application\ Support/M3MCP/mcp.sock \

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AppleMCP — Local Apple Data for AI Assistants</title>
-    <meta name="description" content="Native macOS MCP server giving AI assistants secure, local access to Mail, Calendar, Contacts, Notes, Photos, Reminders, Voice Memos, and Apple Intelligence.">
+    <meta name="description" content="Native macOS MCP server giving AI assistants local access to Mail, Calendar, Contacts, Notes, Photos, Reminders, Voice Memos, and Apple Intelligence.">
     <style>
         :root {
             --bg: #0d1117;
@@ -143,13 +143,13 @@
     <div class="container">
         <header>
             <h1>AppleMCP</h1>
-            <p>Native macOS MCP server that gives AI assistants secure, local access to your Apple data and Apple Intelligence.</p>
+            <p>Native macOS MCP server that gives AI assistants local access to your Apple data and Apple Intelligence.</p>
             <div class="badge-row">
                 <span class="badge blue">macOS 15+</span>
                 <span class="badge blue">Swift</span>
                 <span class="badge">MCP Protocol</span>
                 <span class="badge">Local-first</span>
-                <span class="badge">Privacy-safe</span>
+                <span class="badge">Unix socket, no TCP port</span>
             </div>
         </header>
 
@@ -174,7 +174,7 @@
                 </div>
                 <div class="card">
                     <h3>Reminders</h3>
-                    <p>Search reminders via EventKit. Filter by completion status, due dates, priorities.</p>
+                    <p>Search reminders via EventKit. The query matches title, notes and list name, and completion status is the one filter. Due date and priority come back as metadata; results are sorted by due date.</p>
                 </div>
                 <div class="card">
                     <h3>Photos</h3>
@@ -182,7 +182,7 @@
                 </div>
                 <div class="card">
                     <h3>Voice Memos</h3>
-                    <p>Search recordings in the local CloudRecordings store, read the transcript macOS stores inside each <code>.m4a</code>, or transcribe on device with Speech.framework.</p>
+                    <p>Search recordings in the local CloudRecordings store, read the transcript macOS stores inside each <code>.m4a</code>, or transcribe with Speech.framework, on device where the locale has a model and through Apple's speech service where it does not. Each recognition run is stored under Application Support, so the next call for that recording is free.</p>
                 </div>
             </div>
         </section>
@@ -192,11 +192,11 @@
             <div class="grid">
                 <div class="card">
                     <h3>Writing Tools</h3>
-                    <p>Summarize, rewrite, proofread, or change tone using Apple's on-device writing tools.</p>
+                    <p>Summarize, rewrite, proofread, or change tone. The text goes through a Shortcut named Writing Tools that you create yourself; without it the tool reports that Writing Tools is not reachable.</p>
                 </div>
                 <div class="card">
                     <h3>Translation</h3>
-                    <p>Translate text between languages using the system translation service.</p>
+                    <p>Translate text between languages through a Shortcut named Translate that you create yourself, driven by <code>/usr/bin/python3</code>. Whether the translation stays on the Mac depends on the language pair Shortcuts and Translate have downloaded.</p>
                 </div>
                 <div class="card">
                     <h3>Image Playground</h3>
@@ -257,7 +257,7 @@ curl --unix-socket ~/Library/Application\ Support/M3MCP/mcp.sock \
         </div>
 
         <footer>
-            <p>AppleMCP is open source under the Apache 2.0 license. All data stays on your device.</p>
+            <p>AppleMCP is open source under the Apache 2.0 license. What it reads stays on your device, apart from ai_translate and ai_writing_tools, which pass text to a Shortcut you built, and transcription on locales without an on-device speech model.</p>
             <p style="margin-top: 8px;"><a href="https://godmodeai2025.github.io/MarkZimmermann/" style="color: var(--muted); text-decoration: none;">Impressum</a></p>
         </footer>
     </div>

--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
                 </div>
                 <div class="card">
                     <h3>Voice Memos</h3>
-                    <p>Search recordings in the local CloudRecordings store, read the transcript macOS stores inside each <code>.m4a</code>, or transcribe with Speech.framework, on device where the locale has a model and through Apple's speech service where it does not. Each recognition run is stored under Application Support, so the next call for that recording is free.</p>
+                    <p>Search recordings in the local CloudRecordings store, read the transcript macOS stores inside each <code>.m4a</code>, or transcribe with Speech.framework, on device where the locale has a model and through Apple's speech service where it does not. What it recognizes is written to Application Support, which makes a second call for the same recording cheap. Nothing removes those files afterwards.</p>
                 </div>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -232,6 +232,7 @@ swift build -c release
 swift test
 
 # Install and start it under launchd
+# (needs a code-signing identity: ./script/create_local_identity.sh)
 ./script/install_local.sh
 
 # Add to Claude Desktop (~/Library/Application Support/Claude/claude_desktop_config.json)

--- a/script/check_docs.py
+++ b/script/check_docs.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Checks the documentation against the code it describes.
+
+Every check here derives its expectation from a source file, so it fails when
+the code moves and the prose stays behind. Checks that would pass forever are
+deliberately absent.
+
+  1. Tool parity      new tool in ToolCatalog.swift, not in the README table
+  2. Build config     install_local.sh switches configuration, docs keep the old path
+  3. Write claim      the README calls the server read-only while write tools exist
+  4. Prerequisites    ai_translate shells out to /usr/bin/python3 without saying so
+
+Run: python3 script/check_docs.py
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CATALOG = ROOT / "Sources" / "M3MCPBridge" / "ToolCatalog.swift"
+AI_PROVIDER = ROOT / "Sources" / "M3MCPApp" / "Providers" / "AppleIntelligenceProvider.swift"
+INSTALL = ROOT / "script" / "install_local.sh"
+README = ROOT / "README.md"
+PAGE = ROOT / "index.html"
+
+DOCS = (README, PAGE)
+
+failures = []
+
+
+def fail(check, message):
+    failures.append((check, message))
+
+
+def read(path):
+    if not path.exists():
+        fail("setup", f"{path.relative_to(ROOT)} is missing")
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def catalog_tools(text):
+    return set(re.findall(r'MCPTool\(\s*name:\s*"([a-z0-9_]+)"', text))
+
+
+def readme_tools(text):
+    """Tool names in the first column of the tables under '## MCP Tools'."""
+    section = re.search(r"\n## MCP Tools\n(.*?)(?=\n## )", text, re.S)
+    if not section:
+        fail("tool parity", "README has no '## MCP Tools' section to compare against")
+        return set()
+    return set(re.findall(r"^\|\s*`([a-z0-9_]+)`\s*\|", section.group(1), re.M))
+
+
+def check_tool_parity(catalog_text, readme_text):
+    catalog = catalog_tools(catalog_text)
+    if not catalog:
+        fail("tool parity", "no tools parsed from ToolCatalog.swift, the parser is out of date")
+        return
+    documented = readme_tools(readme_text)
+    for name in sorted(catalog - documented):
+        fail("tool parity", f"{name} is registered in ToolCatalog.swift but missing from the README tables")
+    for name in sorted(documented - catalog):
+        fail("tool parity", f"{name} is in the README tables but no longer registered in ToolCatalog.swift")
+
+
+def check_build_configuration(install_text):
+    match = re.search(r'CONFIGURATION="\$\{M3MCP_CONFIGURATION:-([a-z]+)\}"', install_text)
+    if not match:
+        fail("build config", "cannot read the default configuration out of script/install_local.sh")
+        return
+    configuration = match.group(1)
+    for path in DOCS:
+        text = read(path)
+        name = path.name
+        paths = set(re.findall(r"\.build/([a-z]+)/M3MCPBridge", text))
+        if not paths:
+            fail("build config", f"{name} names no bridge binary, so nobody can wire up an MCP client")
+        for found in sorted(paths - {configuration}):
+            fail(
+                "build config",
+                f"{name} points at .build/{found}/M3MCPBridge while install_local.sh builds {configuration}",
+            )
+        expected_command = "swift build" if configuration == "debug" else f"swift build -c {configuration}"
+        if expected_command not in text:
+            fail("build config", f"{name} has no '{expected_command}', so its own bridge path is never produced")
+
+
+def check_write_claim(catalog_text):
+    writers = sorted(n for n in catalog_tools(catalog_text) if re.search(r"_(create|update|delete)", n))
+    if not writers:
+        return
+    blanket = re.compile(r"read[-\s]?only\s+(access|MCP|server)", re.I)
+    for path in DOCS:
+        hit = blanket.search(read(path))
+        if hit:
+            fail(
+                "write claim",
+                f"{path.name} still promises {hit.group(0)!r} while {len(writers)} write tools ship: "
+                + ", ".join(writers),
+            )
+
+
+def check_translate_prerequisites(provider_text, readme_text):
+    interpreter = "/usr/bin/python3"
+    in_code = interpreter in provider_text
+    in_readme = interpreter in readme_text
+    if in_code and not in_readme:
+        fail("prerequisites", f"AppleIntelligenceProvider shells out to {interpreter}, the README never mentions it")
+    if in_readme and not in_code:
+        fail("prerequisites", f"the README requires {interpreter}, no provider uses it any more")
+
+
+def main():
+    catalog_text = read(CATALOG)
+    readme_text = read(README)
+    check_tool_parity(catalog_text, readme_text)
+    check_build_configuration(read(INSTALL))
+    check_write_claim(catalog_text)
+    check_translate_prerequisites(read(AI_PROVIDER), readme_text)
+
+    if failures:
+        print(f"{len(failures)} documentation problem(s):\n")
+        for check, message in failures:
+            print(f"  [{check}] {message}")
+        return 1
+
+    print(f"Documentation matches the code: {len(catalog_tools(catalog_text))} tools, "
+          "build configuration, write claim, ai_translate prerequisites.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## CI, und ein README, das wieder stimmt

Das Repo hatte keine CI, und das README beschrieb einen Stand, den es seit PR #11 nicht mehr gibt. Beides in einem Zug, weil die Doku-Pruefung der CI die Falschaussagen selbst gefunden hat.

### Was die CI prueft

Zwei Jobs, ausgeloest von push und pull_request nach main sowie von workflow_dispatch.

**Job `swift` auf `macos-26`**

1. Ein Guard prueft, ob das SDK des Runners `FoundationModels.framework` mitbringt.
2. `swift build`
3. `swift test`, die 23 Faelle aus `Tests/M3MCPCoreTests`
4. `swift build -c release`, weil `script/install_local.sh` genau so baut und Whole-Module-Optimierung Fehler zeigt, die der Debug-Build durchlaesst

Zur Runner-Wahl: `Package.swift` gibt `-weak_framework FoundationModels` unbedingt an den Linker weiter, und dieses Framework gibt es erst im macOS-26-SDK. Der Compiler stoert sich nicht daran, weil `FoundationModelsProvider.swift` hinter `#if canImport(FoundationModels)` steht. Der Linker schon. In einer Kopie nachgestellt, indem der Flag auf ein im SDK fehlendes Framework zeigt:

```
ld: framework 'FoundationModelsAbsentFromThisSDK' not found
error: link command failed with exit code 1
```

Auf `macos-15` mit einem Xcode-16-SDK waere das der Zustand fuer `FoundationModels` selbst. `macos-14` ist in `actions/runner-images` ohnehin als deprecated gefuehrt. `macos-26` ist seit Februar 2026 GA, hat Xcode 26.6 (17F113) als Standard und damit denselben Compiler, gegen den hier lokal gebaut wurde. Der SDK-Guard steht davor, damit ein spaeterer Wechsel des Standard-Xcode nicht als kryptischer ld-Fehler ankommt, sondern als Satz, der sagt, was zu tun ist.

**Job `docs` auf `ubuntu-latest`** fuehrt `script/check_docs.py` aus. Das Skript leitet jede Erwartung aus einer Quelldatei ab, damit es rot wird, wenn der Code sich bewegt und der Text stehen bleibt:

- jedes Werkzeug aus `ToolCatalog.swift` steht in den README-Tabellen und umgekehrt
- die Konfiguration, mit der `install_local.sh` baut, ist die, auf die README und `index.html` zeigen
- solange Schreibwerkzeuge im Katalog stehen, darf kein Dokument `read-only access` versprechen
- greift der Provider auf `/usr/bin/python3` zu, muss das README es nennen, und faellt der Zugriff weg, darf die Zeile nicht stehenbleiben

Gegen den Stand vor dieser Reihe meldete das Skript sieben Treffer, darunter `mail_list_mailboxes`, das seit PR #13 im Katalog steht und in keiner Tabelle auftauchte.

### Was die CI nicht prueft

Kein Provider, kein `LocalHTTPServer`, kein Bridge-Protokoll. Die Tests decken den Voice-Memos-Transkript-Parser und den Kalender-Slug ab, mehr gibt es nicht. Auf einem Runner ohne erteilte TCC-Berechtigungen waeren Provider-Tests entweder rot oder uebersprungen, also Fassade. Die Luecke steht im README unter Limits und in der Roadmap, statt sie mit einem gruenen Haken zu verdecken. Ebenso wenig geprueft: das Signieren, der LaunchAgent, das Verhalten der Apple-Intelligence-Werkzeuge. Dafuer braucht es einen Mac mit Berechtigungen und einem angemeldeten Nutzer.

Jeder Schritt wurde lokal genau so ausgefuehrt, wie er im Workflow steht, alle vier gruen. Zum Beleg, dass sie beissen koennen, wurden sieben kuenstliche Brueche in Kopien getestet, jeder wurde rot. Der aussagekraeftigste: `markerKey` in `CalendarProjectSlug.swift` von `"Project"` auf `"Projekt"` umbenannt. `swift build` blieb gruen, `swift test` fiel mit 8 von 23 Faellen um.

### Welche Aussagen korrigiert wurden

- **read-only.** Das README versprach `secure, read-only access`. Seit PR #11 stehen fuenf Kalender-Schreibwerkzeuge im Katalog, und `ai_image_playground` schreibt pro Aufruf eine PNG-Datei ins temporaere Verzeichnis (`AppleIntelligenceProvider.swift`, Zeile 174). Einleitung, Uebersichtstabelle und Landingpage sagen das jetzt.
- **Quickstart.** Er fuehrte in `.build/debug/M3MCPBridge`, waehrend `install_local.sh` mit `-c release` baut. Diesen Pfad hat der dokumentierte Installationsweg nie erzeugt. Jetzt durchgehend release, mit `create_local_identity.sh` davor, weil `install_local.sh` ohne Signatur-Identitaet abbricht.
- **Grenzen.** Neuer Abschnitt Limits: der Socket unterscheidet unsandboxed Prozesse desselben Nutzers nicht (Issue #9), `ai_translate` braucht einen selbst angelegten Shortcut namens Translate und `/usr/bin/python3`, `ai_writing_tools` braucht einen Shortcut namens Writing Tools, die PNG-Dateien bleiben liegen, Kalender-Schreiben hat kein Undo, die Testabdeckung ist schmal, zum Bauen braucht es das macOS-26-SDK.
- **Roadmap.** Neuer Abschnitt, getrennt in das, was als Issue existiert (#9, #10 mit PR #14), und das, was noch keins hat.
- **Was AppleMCP nicht ist.** Keine GUI-Automation, keine Screenshots, kein Computer-Use, kein Mailversand, kein Netzwerk. Mit `grep` gegen `Sources` gegengeprueft: kein `System Events`, kein `AXUIElement`, kein `CGEvent`, kein `ScreenCaptureKit`.
- **Berechtigungstexte.** Die Kalender-Usage-Strings in der `Info.plist` sagten nur "liest". Genau dieser Text erscheint im macOS-Dialog, der die Schreibberechtigung holt.
- **`docs/BEST_PRACTICES.md`** verlangte read-only Datenwerkzeuge, was das Repo selbst nicht mehr einhaelt.
- **`index.html`** nannte `~/.config/claude/` als Ort der Claude-Desktop-Konfiguration. Unter macOS liegt sie in `~/Library/Application Support/Claude/`.

`SECURITY.md` ist verlinkt, nicht kopiert. Sie liegt als PR #14.

Der dritte Commit nimmt Ueberzeichnungen zurueck, die im ersten Anlauf in meine eigenen neuen Absaetze gerutscht waren, allen voran "the sources contain no HTTP client": `LocalAppClient.swift` Zeile 135 baut HTTP-Requests zusammen, nur eben ueber den Unix-Socket.

### Was offen bleibt

- Der Socket prueft weiterhin nicht, wer verbindet (Issue #9). Dateirechte halten Sandbox-Apps und Webseiten fern, sonst nichts.
- Kein Sicherheitsnetz fuer die Schreibwerkzeuge: kein Dry-Run, keine Bestaetigung.
- Keine Tests fuer Provider und Bridge, deshalb bleibt die CI eine Build- und Parser-Absicherung.
- Kein getaggtes Release, der Source-Build ist weiter der einzige Weg.
- Issues #9 und #10 haben immer noch keine Labels und keinen Milestone. Sie sind im README verlinkt, mehr war ohne schreibende API-Aufrufe nicht moeglich.
- Der Befund aus der Gegenpruefung, `mail_search` verliere stille Body-Treffer bei kombinierten Feldern, ist hier nicht angefasst. Codefehler, nicht Textfehler, und ungeprueft.

## Wie dieser Branch entstanden ist

Drei Durchgaenge, jeder mit eigener Abnahme:

1. CI anlegen und die im Haerteplan gelisteten Falschaussagen korrigieren.
2. Die Abnahme hat die CI selbst nachgefahren, absichtlich gebrochen, um zu pruefen ob sie Zaehne
   hat, und dabei 9 weitere Aussagen gefunden, die immer noch nicht stimmten. Die wurden im
   zweiten Durchgang korrigiert.
3. Die Nachpruefung des zweiten Durchgangs fand Formulierungen, die beim Korrigieren zu weit
   gingen oder eine neue Ungenauigkeit einfuehrten. Die wurden im dritten Durchgang praezisiert.

Jede Zahl in den geaenderten Texten ist gegen das Repo gemessen, nicht uebernommen.

## Zur CI

Die CI prueft nur, was heute wirklich pruefbar ist. Sie wurde absichtlich gebrochen, um zu
belegen, dass ein realistischer Fehler sie rot macht. Was sie nicht abdeckt, steht in der
Beschreibung der einzelnen Schritte.


---
Dieser PR sitzt direkt auf `main`. Fuer dieses Repo gab es keine Welle-2-Aenderungen, weil sich der dort vermutete Fehler beim Nachpruefen nicht bestaetigt hat.

Teil von Welle 3 des Haerteplans: CI sichtbar und Claims ehrlich. Jede Aenderung wurde von einem zweiten Durchgang abgenommen, der die CI-Schritte selbst nachgefahren und die CI absichtlich gebrochen hat.
