### PR TITLE
Socket-Authentifizierung: Capability-Token und Peer-Pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Run concurrency security tests with ThreadSanitizer
         run: >-
           swift test --sanitize=thread --filter
-          'PermissionProviderCancellationTests|RemindersProviderCancellationTests|LegacySpeechRecognizerCancellationTests|SpeechPrivacyPolicyTests|NativeToolApprovalCoordinatorTests|AppleScriptRunnerCancellationTests|AutomationPermissionPreflightTests|MailProviderCancellationTests|MailProviderSQLiteSecurityTests|LocalHTTPServerCancellationTests|LocalHTTPServerStartLockTests|MCPServerFormattingTests|LocalHTTPResponseTests|InFlightRequestRegistryTests|BoundedProcessRunnerTests|SensitiveTemporaryArtifactsTests|AppStartupCleanupTests|ShortcutRunnerTests|VoiceMemosRecordingSecurityTests|VoiceMemosSnapshotSecurityTests'
+          'PermissionProviderCancellationTests|RemindersProviderCancellationTests|LegacySpeechRecognizerCancellationTests|SpeechPrivacyPolicyTests|NativeToolApprovalCoordinatorTests|AppleScriptRunnerCancellationTests|AutomationPermissionPreflightTests|MailProviderCancellationTests|MailProviderSQLiteSecurityTests|LocalHTTPServerCancellationTests|LocalHTTPServerStartLockTests|MCPServerFormattingTests|LocalHTTPResponseTests|InFlightRequestRegistryTests|BoundedProcessRunnerTests|SensitiveTemporaryArtifactsTests|AppStartupCleanupTests|ShortcutRunnerTests|VoiceMemosRecordingSecurityTests|VoiceMemosSnapshotSecurityTests|SocketAuthenticationTests|SocketPeerPinTests|SocketAvailabilityTests'
 
       - name: Build release binaries
         run: swift build -c release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@
   overrides the sibling lookup. Where no sibling bridge exists the pin cannot be computed and the
   endpoint says so instead of implying it. `script/install_local.sh` now stages, signs, and commits
   the bridge together with the app, the way `script/package_release.sh` already did.
+- **Silence no longer takes the endpoint away.** Accepted connections are read through a dispatch
+  source on a serial queue instead of a thread parked in `read`, so a connection that has sent
+  nothing costs a descriptor and a deadline. Two caps replace one: 128 connections waiting for a
+  request, 16 requests being served. At the waiting cap the connection that has waited longest
+  without sending a byte is displaced by a new arrival, and the listen backlog is matched to the cap
+  so a burst is queued rather than met with ECONNREFUSED. Measured on the same probe: with 16 silent
+  connections the previous build answered `GET /health` and every tool call with 503, and this one
+  answers 200; under a four-thread reconnect flood it went from 4 percent of calls answered to 98
+  percent. A connection that has sent something is never displaced, and when every serving slot is
+  busy the refusal is still 503.
 
 ## 0.3.0 — 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Security
+
+- **Capability token on the socket.** The app generates a 32-byte secret on its first start, keeps it
+  in the login keychain, and refuses every request other than `GET /health` that does not present it
+  as `Authorization: Bearer <token>`, compared in constant time. `M3MCP_TOKEN` overrides the keychain
+  in both processes. If no token can be read or created the listener does not start. `Server › Copy
+  MCP Client Token` puts it on the pasteboard; the bridge resolves it on its first tool call, so
+  `initialize` and `tools/list` still answer on a machine with no app and no keychain item.
+- **`/status` is no longer open.** It carries the activity log with tool inputs and bounded outputs,
+  so it now needs the token. `/health` stays open and keeps omitting the log.
+
 ## 0.3.0 — 2026-09-04
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
   `initialize` and `tools/list` still answer on a machine with no app and no keychain item.
 - **`/status` is no longer open.** It carries the activity log with tool inputs and bounded outputs,
   so it now needs the token. `/health` stays open and keeps omitting the log.
+- **Pinned client binary.** At every start the app reads the code directory hash of the
+  `M3MCPBridge` next to its own executable and accepts connections from that binary alone; a valid
+  token from anywhere else is `403`. The identity comes from the peer's audit token rather than its
+  pid, and `SecCodeCheckValidity` runs alongside the hash comparison. `M3MCP_TRUSTED_CLIENT_CDHASH`
+  overrides the sibling lookup. Where no sibling bridge exists the pin cannot be computed and the
+  endpoint says so instead of implying it. `script/install_local.sh` now stages, signs, and commits
+  the bridge together with the app, the way `script/package_release.sh` already did.
 
 ## 0.3.0 — 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@
   pid, and `SecCodeCheckValidity` runs alongside the hash comparison. `M3MCP_TRUSTED_CLIENT_CDHASH`
   overrides the sibling lookup. Where no sibling bridge exists the pin cannot be computed and the
   endpoint says so instead of implying it. `script/install_local.sh` now stages, signs, and commits
-  the bridge together with the app, the way `script/package_release.sh` already did.
+  the bridge together with the app, the way `script/package_release.sh` already did, and
+  `script/build_and_run.sh` stages one into its `dist/M3MCP.app` for the same reason. README and the
+  landing page now name which bridge to configure for each way of running the app: after an install
+  the copy in `.build/release/` is a different binary to the pin and is refused.
 - **Silence no longer takes the endpoint away.** Accepted connections are read through a dispatch
   source on a serial queue instead of a thread parked in `read`, so a connection that has sent
   nothing costs a descriptor and a deadline. Two caps replace one: 128 connections waiting for a

--- a/README.md
+++ b/README.md
@@ -118,7 +118,17 @@ curl --unix-socket "$HOME/Library/Application Support/M3MCP/mcp.sock" \
   http://localhost/health
 ```
 
-`/health` omits recent tool activity. `/status` includes recent inputs and bounded outputs and should be treated as sensitive local diagnostics.
+`/health` omits recent tool activity and is the one route that answers without a capability token,
+because it is the readiness probe the installer waits on. Every other route, `/status` and every
+tool call included, needs `Authorization: Bearer <token>`. `/status` includes recent inputs and
+bounded outputs and should be treated as sensitive local diagnostics.
+
+```bash
+curl --unix-socket "$HOME/Library/Application Support/M3MCP/mcp.sock" \
+  -H "Authorization: Bearer $M3MCP_TOKEN" \
+  -H 'Content-Type: application/json' -d '{}' \
+  http://localhost/tools/source_status
+```
 
 ### Connect an MCP client
 
@@ -128,7 +138,8 @@ Claude Desktop example:
 {
   "mcpServers": {
     "applemcp": {
-      "command": "/path/to/AppleMCP/.build/debug/M3MCPBridge"
+      "command": "/path/to/AppleMCP/.build/debug/M3MCPBridge",
+      "env": { "M3MCP_TOKEN": "<token from the app's Server menu>" }
     }
   }
 }
@@ -137,8 +148,14 @@ Claude Desktop example:
 Claude Code example:
 
 ```bash
-claude mcp add applemcp /path/to/AppleMCP/.build/debug/M3MCPBridge
+claude mcp add applemcp --env M3MCP_TOKEN="<token>" /path/to/AppleMCP/.build/debug/M3MCPBridge
 ```
+
+The app creates the capability token on its first start and keeps it in the login keychain. Copy it
+with Server › Copy MCP Client Token and put it in the client's configuration. Without it the app
+refuses every tool call. The bridge can also read the item from the keychain, which works only for
+the binary the item is on the ACL of and never prompts, because an MCP client gives the bridge no
+session in which a panel could be answered.
 
 The app must be running while the bridge is in use. The app and bridge independently resolve their immutable security policy at process launch, so optional features must be enabled for both processes.
 
@@ -255,7 +272,15 @@ MCP client <--stdio--> M3MCPBridge <--HTTP over Unix socket--> M3MCPApp
 
 ## Security boundary
 
-The Unix socket prevents browser access and restricts other macOS users. It is not authentication against an unsandboxed process running under the same user account: such a process can normally reach a `0600` socket owned by that user and would inherit whatever data access the app exposes. Treat every MCP client and every same-user unsandboxed process as inside the local trust boundary.
+The Unix socket prevents browser access and restricts other macOS users. It is not authentication on
+its own: a `0600` socket is reachable by every unsandboxed process of the same user. That is what the
+capability token is for. The app generates a 32-byte secret on its first start, keeps it in the login
+keychain, and refuses every request other than `GET /health` that does not present it as
+`Authorization: Bearer <token>`, compared in constant time. A process without the token can still
+open the socket and can still read `/health`; it cannot call a tool.
+
+A token is a secret in a configuration file, so it does not survive being copied. Treat every MCP
+client that holds it as inside the local trust boundary.
 
 The server rejects malformed or oversized framing, limits concurrent connections, enforces an absolute request-receive deadline plus I/O timeouts, and closes active work on shutdown. These controls reduce accidental and hostile resource consumption but do not turn the endpoint into a multi-tenant service.
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,23 @@ then run the staged installer:
 ```
 
 The installer builds the release configuration, validates the signed bundle, stages replacements,
-and commits them only after launchd and the Unix-socket health check succeed. Its bridge is at
-`.build/release/M3MCPBridge`; the one-off development commands below use `.build/debug/M3MCPBridge`.
+and commits them only after launchd and the Unix-socket health check succeed. It builds its bridge at
+`.build/release/M3MCPBridge` and installs a copy of it into the bundle; the one-off development
+commands below use `.build/debug/M3MCPBridge`.
+
+**Point the MCP client at the bridge that sits next to the app it will talk to.** The app accepts
+connections only from the `M3MCPBridge` beside its own executable, so:
+
+| The app you run | The bridge to configure |
+|---|---|
+| `swift build` plus `.build/<config>/M3MCPApp` | `.build/<config>/M3MCPBridge` |
+| `./script/build_and_run.sh` | `dist/M3MCP.app/Contents/MacOS/M3MCPBridge` |
+| `./script/install_local.sh` | `~/Applications/M3MCP.app/Contents/MacOS/M3MCPBridge` |
+| A downloaded release ZIP | `M3MCP.app/Contents/MacOS/M3MCPBridge` |
+
+After an install the copy in `.build/release/` is refused with `403`, even though it was built from
+the same source: the installer re-signs the staged bridge with your stable certificate, which changes
+its code directory hash. That is the pin working, not a bug. The installer prints the path to use.
 
 The app listens on a Unix domain socket at:
 
@@ -148,7 +163,7 @@ Claude Desktop example:
 Claude Code example:
 
 ```bash
-claude mcp add applemcp --env M3MCP_TOKEN="<token>" /path/to/AppleMCP/.build/debug/M3MCPBridge
+claude mcp add applemcp -e M3MCP_TOKEN="<token>" -- /path/to/AppleMCP/.build/debug/M3MCPBridge
 ```
 
 The app creates the capability token on its first start and keeps it in the login keychain. Copy it
@@ -222,7 +237,8 @@ environment. Installation commits only after launchd reports the replacement job
 the installer restores the previous app bundle and LaunchAgent and attempts to restart the previous
 service.
 
-Pass the same variables to the bridge in the MCP client configuration:
+Pass the same variables to the bridge in the MCP client configuration, alongside the capability
+token, and use the bridge path from the table above for the app you actually run:
 
 ```json
 {
@@ -230,6 +246,7 @@ Pass the same variables to the bridge in the MCP client configuration:
     "applemcp": {
       "command": "/path/to/AppleMCP/.build/release/M3MCPBridge",
       "env": {
+        "M3MCP_TOKEN": "<token from the app's Server menu>",
         "M3MCP_ENABLE_CALENDAR_MUTATIONS": "1",
         "M3MCP_ENABLE_PERMISSION_UI": "1",
         "M3MCP_ENABLE_USER_SHORTCUTS": "1"

--- a/README.md
+++ b/README.md
@@ -279,8 +279,17 @@ keychain, and refuses every request other than `GET /health` that does not prese
 `Authorization: Bearer <token>`, compared in constant time. A process without the token can still
 open the socket and can still read `/health`; it cannot call a tool.
 
-A token is a secret in a configuration file, so it does not survive being copied. Treat every MCP
-client that holds it as inside the local trust boundary.
+A token is a secret in a configuration file, so a copy of it works. That is what the second factor is
+for. At every start the app reads the code directory hash of the `M3MCPBridge` sitting next to its own
+executable and accepts connections from that binary and no other. A valid token presented by anything
+else is `403`, not `401`, because the two say different things: the first means "configure a token",
+the second means "that token is not yours to use from there". Where no sibling bridge is found the pin
+cannot be computed; the app then runs token-only and says so in its window, in `source_status`, and in
+`/health`.
+
+What the pin is not: proof of who is calling. It identifies the binary on the other end, and the
+bundled bridge satisfies it whichever process starts it. A stolen token plus that bridge is still a
+working client, so treat every MCP client that holds the token as inside the local trust boundary.
 
 The server rejects malformed or oversized framing, limits concurrent connections, enforces an absolute request-receive deadline plus I/O timeouts, and closes active work on shutdown. These controls reduce accidental and hostile resource consumption but do not turn the endpoint into a multi-tenant service.
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,14 @@ What the pin is not: proof of who is calling. It identifies the binary on the ot
 bundled bridge satisfies it whichever process starts it. A stolen token plus that bridge is still a
 working client, so treat every MCP client that holds the token as inside the local trust boundary.
 
-The server rejects malformed or oversized framing, limits concurrent connections, enforces an absolute request-receive deadline plus I/O timeouts, and closes active work on shutdown. These controls reduce accidental and hostile resource consumption but do not turn the endpoint into a multi-tenant service.
+The server rejects malformed or oversized framing, enforces an absolute request-receive deadline plus
+I/O timeouts, and closes active work on shutdown. Its two connection caps are separate on purpose: up
+to 128 accepted connections may be waiting for a request, each costing a descriptor and no thread, and
+up to 16 framed requests may be served at once. At the waiting cap the connection that has waited
+longest without sending a byte yields its place to a new arrival, so a process that opens connections
+and says nothing cannot take the endpoint away from the client that holds the token. These controls
+reduce accidental and hostile resource consumption but do not turn the endpoint into a multi-tenant
+service.
 
 For vulnerability reporting and supported versions, see [SECURITY.md](SECURITY.md). For the detailed
 threat model, network caveats, diagnostics, data retention, and release checklist, see

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,9 @@ release checklist are in [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md). In pa
 
 - a `0700` directory and `0600` socket exclude other users and normally sandboxed apps; a same-user
   unsandboxed process is stopped by the capability token, which every route other than `GET /health`
-  requires and which a client that holds a copy of can still present;
+  requires, and by a pin on the connecting binary's code directory hash;
+- the pin identifies a binary, not a caller: the bundled `M3MCPBridge` satisfies it whichever process
+  starts it, so a stolen token used through that bridge is still a working client;
 - Mail, Notes, Calendar text, transcripts, filenames, and other provider data remain untrusted
   content even when marked with the machine-readable provenance boundary;
 - Calendar mutation, permission UI, and user-created Shortcuts are separate launch-time opt-ins;

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,8 +32,9 @@ arrives within two weeks, follow up in the private advisory.
 The maintained threat model, implemented controls, residual limitations, retention behavior, and
 release checklist are in [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md). In particular:
 
-- a `0700` directory and `0600` socket exclude other users and normally sandboxed apps, but do not
-  authenticate an unsandboxed process running as the same user;
+- a `0700` directory and `0600` socket exclude other users and normally sandboxed apps; a same-user
+  unsandboxed process is stopped by the capability token, which every route other than `GET /health`
+  requires and which a client that holds a copy of can still present;
 - Mail, Notes, Calendar text, transcripts, filenames, and other provider data remain untrusted
   content even when marked with the machine-readable provenance boundary;
 - Calendar mutation, permission UI, and user-created Shortcuts are separate launch-time opt-ins;

--- a/Sources/M3MCPApp/App/M3MCPApp.swift
+++ b/Sources/M3MCPApp/App/M3MCPApp.swift
@@ -28,6 +28,13 @@ struct M3MCPApp: App {
                 }
                 .keyboardShortcut("p", modifiers: [.command, .shift])
 
+                Button("Copy MCP Client Token") {
+                    model.copyCapabilityToken()
+                }
+                .keyboardShortcut("t", modifiers: [.command, .shift])
+
+                Divider()
+
                 Button("Start") {
                     model.startIfNeeded()
                 }

--- a/Sources/M3MCPApp/Models/AppModel.swift
+++ b/Sources/M3MCPApp/Models/AppModel.swift
@@ -63,9 +63,15 @@ final class AppModel: ObservableObject {
             return
         }
 
-        let authorizer = SocketAuthorizer(token: credentials.token)
+        let trust = TrustedClient.resolve(appExecutableURL: Bundle.main.executableURL)
+        let authorizer = SocketAuthorizer(
+            token: credentials.token,
+            trustedCodeDirectoryHashes: trust.hashes,
+            trustDescription: trust.note
+        )
         capabilityToken = credentials.token
         authenticationSummary = "\(authorizer.pinningDescription); token from \(credentials.origin)"
+        AppLogger.log("Client authentication: \(trust.note)")
 
         let localService = service
         let server = LocalHTTPServer(
@@ -99,7 +105,7 @@ final class AppModel: ObservableObject {
                 // Only refusals are recorded. A granted call is already an activity entry of its own,
                 // and one line per accepted request would bury it.
                 guard !attempt.allowed else { return }
-                AppLogger.log("Refused \(attempt.method) \(attempt.path)")
+                AppLogger.log("Refused \(attempt.method) \(attempt.path) from \(attempt.peer.description)")
                 Task { @MainActor in
                     self?.record(
                         tool: "access_refused",
@@ -107,7 +113,14 @@ final class AppModel: ObservableObject {
                             ok: false,
                             source: "M3MCP Server",
                             message: attempt.reason ?? "Refused",
-                            meta: ["path": attempt.path, "method": attempt.method]
+                            meta: [
+                                "path": attempt.path,
+                                "method": attempt.method,
+                                "peer_pid": String(attempt.peer.processIdentifier),
+                                "peer_identifier": attempt.peer.signingIdentifier ?? "",
+                                "peer_cdhash": attempt.peer.codeDirectoryHash ?? "",
+                                "peer_path": attempt.peer.executablePath ?? ""
+                            ]
                         ),
                         durationMilliseconds: 0
                     )
@@ -147,7 +160,7 @@ final class AppModel: ObservableObject {
         ServiceHealth(
             name: "Client Authentication",
             endpoint: "m3mcp://auth",
-            mode: "capability token",
+            mode: "capability token + peer code identity",
             state: authorizer.pinningDescription
         )
     }

--- a/Sources/M3MCPApp/Models/AppModel.swift
+++ b/Sources/M3MCPApp/Models/AppModel.swift
@@ -9,6 +9,7 @@ final class AppModel: ObservableObject {
     @Published private(set) var permissionItems: [DataItem] = []
     @Published private(set) var permissionMessage: String?
     @Published private(set) var serverState = "stopped"
+    @Published private(set) var authenticationSummary = "not started"
     @Published var selectedServiceName: String?
 
     let securityPolicy: M3MCPSecurityPolicy
@@ -16,6 +17,10 @@ final class AppModel: ObservableObject {
     private let service: LocalMCPService
     private let startupCleanupTask = AppStartupCleanupTask()
     private var server: LocalHTTPServer?
+
+    /// Held so the Server menu can put it on the pasteboard. It never goes into an activity entry,
+    /// into `/health`, or into a log line.
+    private var capabilityToken: String?
 
     init(securityPolicy: M3MCPSecurityPolicy = .fromProcessEnvironment()) {
         let approvalCoordinator = NativeToolApprovalCoordinator()
@@ -37,9 +42,35 @@ final class AppModel: ObservableObject {
         guard server == nil else { return }
         serverState = "starting"
 
+        // Fail closed. If the token cannot be read or created the server does not come up at all:
+        // starting it without one would put the endpoint back where it was before this existed,
+        // reachable by every process of the user.
+        let credentials: CapabilityToken.Resolution
+        do {
+            credentials = try CapabilityToken.loadOrCreate()
+        } catch {
+            serverState = "failed"
+            let message = "No capability token, so the endpoint stays closed: \(error.localizedDescription). "
+                + "Unlock the login keychain and start again, or set \(CapabilityToken.environmentKey) "
+                + "for this run."
+            authenticationSummary = "unavailable"
+            AppLogger.log(message)
+            record(
+                tool: "server_start",
+                response: ToolResponse(ok: false, source: "M3MCP Server", message: message),
+                durationMilliseconds: 0
+            )
+            return
+        }
+
+        let authorizer = SocketAuthorizer(token: credentials.token)
+        capabilityToken = credentials.token
+        authenticationSummary = "\(authorizer.pinningDescription); token from \(credentials.origin)"
+
         let localService = service
         let server = LocalHTTPServer(
             socketURL: M3MCPEndpoint.socketURL,
+            authorizer: authorizer,
             toolHandler: { [weak self] tool, input in
                 let started = Date()
                 let response = await localService.handle(tool: tool, input: input)
@@ -63,6 +94,24 @@ final class AppModel: ObservableObject {
                         recentActivity: []
                     )
                 }
+            },
+            auditHandler: { [weak self] attempt in
+                // Only refusals are recorded. A granted call is already an activity entry of its own,
+                // and one line per accepted request would bury it.
+                guard !attempt.allowed else { return }
+                AppLogger.log("Refused \(attempt.method) \(attempt.path)")
+                Task { @MainActor in
+                    self?.record(
+                        tool: "access_refused",
+                        response: ToolResponse(
+                            ok: false,
+                            source: "M3MCP Server",
+                            message: attempt.reason ?? "Refused",
+                            meta: ["path": attempt.path, "method": attempt.method]
+                        ),
+                        durationMilliseconds: 0
+                    )
+                }
             }
         )
 
@@ -71,7 +120,7 @@ final class AppModel: ObservableObject {
             self.server = server
             serverState = "running"
             AppLogger.log("Local server listening on \(M3MCPEndpoint.socketURL.path)")
-            services = service.services
+            services = service.services + [authenticationService(authorizer)]
             record(
                 tool: "server_start",
                 response: ToolResponse(ok: true, source: "M3MCP Server", message: "Listening on \(M3MCPEndpoint.displayPath)"),
@@ -92,10 +141,37 @@ final class AppModel: ObservableObject {
         startupCleanupTask.startIfNeeded()
     }
 
+    /// The one row in the service list that describes the endpoint's own door rather than a data
+    /// source. `/health` carries it too, so a degraded install is visible from outside the app.
+    private func authenticationService(_ authorizer: SocketAuthorizer) -> ServiceHealth {
+        ServiceHealth(
+            name: "Client Authentication",
+            endpoint: "m3mcp://auth",
+            mode: "capability token",
+            state: authorizer.pinningDescription
+        )
+    }
+
+    /// Puts the token on the pasteboard so it can go into an MCP client config. Returns what to show
+    /// the user; the token itself never appears in a log or in a status reply.
+    @discardableResult
+    func copyCapabilityToken() -> String {
+        guard let capabilityToken else {
+            return "The server is not running, so there is no token to copy."
+        }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(capabilityToken, forType: .string)
+        return "Capability token copied. Put it in your MCP client config as "
+            + "\"env\": {\"\(CapabilityToken.environmentKey)\": \"…\"}."
+    }
+
     func stop() {
         server?.stop()
         server = nil
         serverState = "stopped"
+        capabilityToken = nil
+        authenticationSummary = "not started"
+        services = service.services
         record(
             tool: "server_stop",
             response: ToolResponse(ok: true, source: "M3MCP Server", message: "Stopped"),

--- a/Sources/M3MCPApp/Services/LocalHTTPServer.swift
+++ b/Sources/M3MCPApp/Services/LocalHTTPServer.swift
@@ -16,8 +16,9 @@ private func m3mcpFlock(_ descriptor: Int32, _ operation: Int32) -> Int32
 ///
 /// The filesystem is only part of the access control, because it stops at the user boundary: every
 /// unsandboxed process of the same user could connect and inherit the app's Full Disk Access. So
-/// every request other than `GET /health` has to present the capability token. `SocketAuthorizer`
-/// holds the rules.
+/// every request other than `GET /health` has to present the capability token, and where the app
+/// could work out which binary its bridge is, the connecting process is checked against that
+/// binary's code directory hash. `SocketAuthorizer` holds the rules, `PeerIdentity` reads the peer.
 final class LocalHTTPServer {
     typealias ToolHandler = (String, [String: JSONValue]) async -> ToolResponse
     /// `includeActivity` is false for the public health probe and true for the diagnostic endpoint.
@@ -878,6 +879,12 @@ final class LocalHTTPServer {
     private func serve(_ client: Int32) {
         switch readRequest(from: client) {
         case .request(let request):
+            // The peer is read here and not at `accept`: resolving it costs a signature check, and a
+            // connection that never delivered a request never reaches an authorization decision.
+            // The descriptor is still the one the peer connected on, so `LOCAL_PEERTOKEN` names the
+            // process that opened it.
+            let peer = PeerIdentity.resolve(descriptor: client)
+
             // Once framing is complete no more client bytes are expected. Keep watching the read
             // side while the async handler runs so a bridge cancellation (`shutdown`) or crashed
             // client promptly cancels the work and returns the connection slot.
@@ -891,7 +898,7 @@ final class LocalHTTPServer {
 
             let task = Task { [weak self] in
                 defer { done.signal() }
-                await self?.respond(to: request, on: client, cancellation: cancellation)
+                await self?.respond(to: request, on: client, peer: peer, cancellation: cancellation)
             }
             cancellation.attach(task)
             done.wait()
@@ -1033,12 +1040,13 @@ final class LocalHTTPServer {
     private func respond(
         to request: LocalHTTPRequest,
         on client: Int32,
+        peer: PeerIdentity,
         cancellation: RequestCancellationState
     ) async {
         guard responseIsAllowed(cancellation) else { return }
 
         if let reason = RequestGuard.rejection(for: request) {
-            report(request, allowed: false, reason: reason)
+            report(request, peer: peer, allowed: false, reason: reason)
             send(status: 403, refusal: reason, path: request.path, to: client, cancellation: cancellation)
             return
         }
@@ -1046,15 +1054,16 @@ final class LocalHTTPServer {
         let decision = authorizer.authorize(
             method: request.method,
             path: request.path,
-            authorizationHeader: request.headers["authorization"]
+            authorizationHeader: request.headers["authorization"],
+            peer: peer
         )
         if case .deny(let status, let reason) = decision {
-            report(request, allowed: false, reason: reason)
+            report(request, peer: peer, allowed: false, reason: reason)
             send(status: status, refusal: reason, path: request.path, to: client, cancellation: cancellation)
             return
         }
 
-        report(request, allowed: true, reason: nil)
+        report(request, peer: peer, allowed: true, reason: nil)
 
         if request.method == "GET", request.path == "/health" {
             let status = await statusHandler(false)
@@ -1095,10 +1104,16 @@ final class LocalHTTPServer {
         send(status: 404, body: ["error": "Not found"], to: client, cancellation: cancellation)
     }
 
-    private func report(_ request: LocalHTTPRequest, allowed: Bool, reason: String?) {
+    private func report(_ request: LocalHTTPRequest, peer: PeerIdentity, allowed: Bool, reason: String?) {
         guard let auditHandler else { return }
         auditHandler(
-            AccessAttempt(method: request.method, path: request.path, allowed: allowed, reason: reason)
+            AccessAttempt(
+                method: request.method,
+                path: request.path,
+                peer: peer,
+                allowed: allowed,
+                reason: reason
+            )
         )
     }
 

--- a/Sources/M3MCPApp/Services/LocalHTTPServer.swift
+++ b/Sources/M3MCPApp/Services/LocalHTTPServer.swift
@@ -29,7 +29,21 @@ final class LocalHTTPServer {
 
     struct Configuration {
         var requestLimits = LocalHTTPRequestParser.Limits()
+        /// How many complete requests may be served at once.
+        ///
+        /// `connectionQueue` is concurrent and each served request blocks a thread on it while its
+        /// async handler runs, so this bounds the endpoint's share of a thread pool. Only a
+        /// connection that has already delivered a whole request gets one; see
+        /// `maximumOpenConnections` for the connections that have not.
         var maximumConcurrentConnections = 16
+        /// How many accepted connections may be waiting for a request at once.
+        ///
+        /// A waiting connection costs a file descriptor and a dispatch source and no thread, so this
+        /// bounds descriptors rather than threads and can be an order of magnitude larger.
+        ///
+        /// The cap does not by itself decide who is turned away when it is reached: a connection that
+        /// has sent nothing yields its place to a newer one. See `acceptPendingConnections`.
+        var maximumOpenConnections = 128
         /// A pre-existing endpoint is probed before it can be classified as stale and removed.
         /// Keep this short because `start()` holds the endpoint lock for the complete probe.
         var existingSocketProbeDeadline: TimeInterval = 0.25
@@ -136,8 +150,17 @@ final class LocalHTTPServer {
         label: "de.markzimmermann.m3mcp.connections",
         attributes: .concurrent
     )
+    /// Serial: every pending connection's reads, its deadline and its teardown run here, so the
+    /// state of a connection needs no lock of its own. Nothing on it may block, because the accept
+    /// loop enters it synchronously to make room for a new arrival.
+    private let readQueue = DispatchQueue(label: "de.markzimmermann.m3mcp.reads")
     private let parser: LocalHTTPRequestParser
+    /// Requests being served. Claimed once a request is framed, released when its reply is done.
     private let connectionSlots: DispatchSemaphore
+    private let openConnectionLock = NSLock()
+    private var openConnections = 0
+    /// Only ever touched on `readQueue`.
+    private var pendingConnections: [PendingConnection] = []
     private let activeConnections = ActiveConnectionRegistry()
     private let configuration: Configuration
     private let socketProbeOperations: SocketProbeOperations
@@ -439,7 +462,10 @@ final class LocalHTTPServer {
             _ = fcntl(descriptor, F_SETFL, flags | O_NONBLOCK)
         }
 
-        guard listen(descriptor, 16) == 0 else {
+        // The backlog is what the kernel holds between a client's connect and this server's accept.
+        // Matching it to the connection cap keeps a burst from being answered with ECONNREFUSED,
+        // which looks to a client like a server that is not running. 128 is where Darwin tops out.
+        guard listen(descriptor, Int32(min(max(1, configuration.maximumOpenConnections), 128))) == 0 else {
             let code = errno
             close(descriptor)
             unlink(path)
@@ -762,31 +788,264 @@ final class LocalHTTPServer {
             var on: Int32 = 1
             setsockopt(client, SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size))
 
-            // Darwin does not pass O_NONBLOCK on to accepted sockets. Keep the descriptor blocking
-            // for its socket-level defence-in-depth timeouts; bounded response writes use
-            // `MSG_DONTWAIT` and `poll` below.
+            // Non-blocking is what makes a silent connection cheap: the request is collected by a
+            // dispatch source, and a connection that sends nothing simply never fires one, so it
+            // costs a descriptor and a deadline instead of a parked thread. Response writes set
+            // O_NONBLOCK themselves and drive their own absolute deadline.
             let clientFlags = fcntl(client, F_GETFL, 0)
             if clientFlags >= 0 {
-                _ = fcntl(client, F_SETFL, clientFlags & ~O_NONBLOCK)
+                _ = fcntl(client, F_SETFL, clientFlags | O_NONBLOCK)
             }
 
+            // Kept as defence in depth. No path below enters a blocking socket call, so these
+            // timeouts are a second bound rather than the primary one.
             guard configureTimeouts(on: client) else {
                 close(client)
                 continue
             }
 
-            // Admission is deliberately non-blocking so slow clients cannot stall the accept loop.
-            // A slot is held through a long-running tool call, but the socket timeouts only cover
-            // individual I/O operations; transcription and other legitimate work remain unbounded.
-            guard connectionSlots.wait(timeout: .now()) == .success else {
-                rejectOverloaded(client)
+            // At the cap, the connection that just arrived is the wrong one to turn away. It is the
+            // one that might have something to say; a slot held without a single byte in it belongs
+            // to a connection that has already shown it has not. So the oldest silent connection is
+            // dropped and the new one takes its place. A process without a token can still fill
+            // every slot, but it cannot keep them: every arrival after that costs it its oldest.
+            //
+            // The bridge writes its whole request in one call straight after `connect`, so it leaves
+            // the silent set within microseconds and is never the connection picked.
+            if !claimOpenConnection() {
+                // Synchronous on purpose. `pendingConnections` belongs to `readQueue`, and waiting
+                // here is also what stops the accept loop from running ahead of its own admissions
+                // and holding an unbounded number of descriptors while it does.
+                var displaced = false
+                readQueue.sync { displaced = self.dropOldestSilentConnection() }
+
+                // Nothing silent left means every slot holds a request being read, and then the
+                // refusal is the honest answer.
+                guard displaced, claimOpenConnection() else {
+                    rejectOverloaded(client)
+                    continue
+                }
+            }
+
+            // Registered before the hand-off to `readQueue`, so `stop()` reaches a connection that
+            // is still waiting for its request and shuts it down like any other.
+            guard activeConnections.register(client) else {
+                releaseOpenConnection()
+                close(client)
                 continue
             }
 
-            guard activeConnections.register(client) else {
-                connectionSlots.signal()
+            readQueue.async { [weak self] in
+                guard let self else {
+                    close(client)
+                    return
+                }
+                self.beginReading(client)
+            }
+        }
+    }
+
+    // MARK: - Reading a request without holding a thread
+
+    /// One connection that has been accepted and has not yet delivered a complete request.
+    ///
+    /// Everything on it belongs to `readQueue`. `outcome` is what the read source's cancel handler
+    /// does with the descriptor, which is the single point where ownership leaves the read phase.
+    private final class PendingConnection {
+        enum Outcome {
+            /// Close without saying anything: the peer hung up, or the descriptor failed.
+            case drop
+            /// Write this reply best-effort, then close.
+            case reply(Data)
+            /// A complete request: hand the descriptor to `connectionQueue`.
+            case serve(LocalHTTPRequest)
+        }
+
+        let descriptor: Int32
+        var buffer = Data()
+        var readSource: DispatchSourceRead?
+        var timer: DispatchSourceTimer?
+        var finished = false
+        var outcome: Outcome = .drop
+
+        init(descriptor: Int32) {
+            self.descriptor = descriptor
+        }
+    }
+
+    private func claimOpenConnection() -> Bool {
+        openConnectionLock.lock()
+        defer { openConnectionLock.unlock() }
+        guard openConnections < max(1, configuration.maximumOpenConnections) else { return false }
+        openConnections += 1
+        return true
+    }
+
+    private func releaseOpenConnection() {
+        openConnectionLock.lock()
+        openConnections = max(0, openConnections - 1)
+        openConnectionLock.unlock()
+    }
+
+    /// Ends the connection that has waited longest without sending a byte, so a newer one can have
+    /// its slot. Runs on `readQueue`, which owns `pendingConnections`.
+    ///
+    /// Returns false when there is nothing silent to drop, which means every slot is held by a
+    /// request that is actually being read. Those are not displaced: a half-read request is work in
+    /// progress, and throwing it away would turn a full endpoint into a lossy one.
+    private func dropOldestSilentConnection() -> Bool {
+        guard let victim = pendingConnections.first(where: { $0.buffer.isEmpty && !$0.finished }) else {
+            return false
+        }
+
+        finish(
+            victim,
+            outcome: .reply(
+                makeResponse(
+                    status: 503,
+                    data: encodedError("Displaced by a newer connection after sending nothing.")
+                )
+            )
+        )
+        return true
+    }
+
+    /// Runs on `readQueue`.
+    private func beginReading(_ client: Int32) {
+        let connection = PendingConnection(descriptor: client)
+
+        let readSource = DispatchSource.makeReadSource(fileDescriptor: client, queue: readQueue)
+        readSource.setEventHandler { [weak self] in
+            self?.readAvailable(on: connection)
+        }
+        // The single hand-off point. Cancelling is how every path leaves the read phase, so the
+        // descriptor has exactly one owner at every moment and `stop()` still only shuts down.
+        readSource.setCancelHandler { [weak self] in
+            guard let self else {
                 close(client)
+                return
+            }
+            self.completePendingConnection(connection)
+        }
+        connection.readSource = readSource
+
+        // The deadline is what an idle connection actually costs: this long, then the slot is back.
+        // It runs from `accept` and not from the last read, so it also bounds a trickle.
+        let timer = DispatchSource.makeTimerSource(queue: readQueue)
+        timer.schedule(deadline: .now() + boundedIOInterval(configuration.requestReadDeadline))
+        timer.setEventHandler { [weak self] in
+            guard let self else { return }
+            self.finish(
+                connection,
+                outcome: .reply(
+                    self.makeResponse(
+                        status: 408,
+                        data: self.encodedError("Timed out while reading the request.")
+                    )
+                )
+            )
+        }
+        connection.timer = timer
+        pendingConnections.append(connection)
+
+        timer.resume()
+        readSource.resume()
+    }
+
+    /// Runs on `readQueue`, so everything it touches on the connection is serialized by the queue.
+    private func readAvailable(on connection: PendingConnection) {
+        guard !connection.finished else { return }
+
+        let maximumBufferedBytes = parser.limits.maximumBufferedBytes
+        var chunk = [UInt8](repeating: 0, count: 16 * 1_024)
+        while true {
+            let remainingCapacity = maximumBufferedBytes - connection.buffer.count
+            guard remainingCapacity > 0 else {
+                finish(connection, outcome: .reply(errorResponse(413, "Request body is too large.")))
+                return
+            }
+
+            let readCapacity = min(chunk.count, remainingCapacity)
+            let count = chunk.withUnsafeMutableBytes { raw -> Int in
+                guard let base = raw.baseAddress else { return -1 }
+                return recv(connection.descriptor, base, readCapacity, MSG_DONTWAIT)
+            }
+
+            if count < 0 {
+                if errno == EINTR { continue }
+                if errno == EAGAIN || errno == EWOULDBLOCK { return }
+                finish(connection, outcome: .drop)
+                return
+            }
+            if count == 0 {
+                // The peer hung up before finishing its request.
+                finish(connection, outcome: .drop)
+                return
+            }
+
+            connection.buffer.append(contentsOf: chunk[0..<count])
+
+            switch parser.parse(connection.buffer) {
+            case .complete(let request):
+                finish(connection, outcome: .serve(request))
+                return
+            case .malformed(let reason):
+                finish(connection, outcome: .reply(errorResponse(400, reason.clientMessage)))
+                return
+            case .tooLarge(.headers):
+                finish(connection, outcome: .reply(errorResponse(431, "Request headers are too large.")))
+                return
+            case .tooLarge(.body):
+                finish(connection, outcome: .reply(errorResponse(413, "Request body is too large.")))
+                return
+            case .incomplete:
                 continue
+            }
+        }
+    }
+
+    /// Ends the read phase. Idempotent, and only ever called on `readQueue`.
+    ///
+    /// The open-connection slot is given back here rather than in the cancel handler, because the
+    /// accept loop re-claims it the instant `dropOldestSilentConnection` returns.
+    private func finish(_ connection: PendingConnection, outcome: PendingConnection.Outcome) {
+        guard !connection.finished else { return }
+        connection.finished = true
+        connection.outcome = outcome
+        pendingConnections.removeAll { $0 === connection }
+        connection.timer?.cancel()
+        connection.timer = nil
+        releaseOpenConnection()
+        connection.readSource?.cancel()
+    }
+
+    /// Runs on `readQueue` as the read source's cancel handler: the one place a pending connection's
+    /// descriptor changes hands.
+    private func completePendingConnection(_ connection: PendingConnection) {
+        connection.readSource = nil
+        let client = connection.descriptor
+
+        switch connection.outcome {
+        case .drop:
+            activeConnections.unregister(client)
+            close(client)
+        case .reply(let data):
+            writeBestEffort(data, to: client)
+            activeConnections.unregister(client)
+            close(client)
+        case .serve(let request):
+            // Only a connection that has actually asked for something is worth a thread.
+            guard connectionSlots.wait(timeout: .now()) == .success else {
+                writeBestEffort(
+                    makeResponse(
+                        status: 503,
+                        data: encodedError("Local endpoint is at its connection limit. Try again shortly.")
+                    ),
+                    to: client
+                )
+                activeConnections.unregister(client)
+                close(client)
+                return
             }
 
             connectionQueue.async { [self] in
@@ -797,9 +1056,13 @@ final class LocalHTTPServer {
                     close(client)
                     connectionSlots.signal()
                 }
-                serve(client)
+                serve(request, on: client)
             }
         }
+    }
+
+    private func errorResponse(_ status: Int, _ message: String) -> Data {
+        makeResponse(status: status, data: encodedError(message))
     }
 
     private func configureTimeouts(on client: Int32) -> Bool {
@@ -846,15 +1109,21 @@ final class LocalHTTPServer {
     }
 
     private func rejectOverloaded(_ client: Int32) {
-        let response = makeResponse(
-            status: 503,
-            data: encodedError("Local endpoint is at its connection limit. Try again shortly.")
+        writeBestEffort(
+            makeResponse(
+                status: 503,
+                data: encodedError("Local endpoint is at its connection limit. Try again shortly.")
+            ),
+            to: client
         )
+        close(client)
+    }
 
-        // The accept queue must never wait for an already-overloaded client. A fresh local socket
-        // normally accepts this small response immediately; if it stops accepting bytes, closing it
-        // is the safe fallback.
-        response.withUnsafeBytes { raw in
+    /// A refusal written without ever blocking. What does not go out is dropped: this path exists to
+    /// explain a refusal, not to guarantee delivery of one, and neither the accept loop nor the read
+    /// queue may wait for a client that will not read.
+    private func writeBestEffort(_ data: Data, to client: Int32) {
+        data.withUnsafeBytes { raw in
             guard let base = raw.baseAddress else { return }
             var offset = 0
             while offset < raw.count {
@@ -873,135 +1142,42 @@ final class LocalHTTPServer {
                 offset += written
             }
         }
-        close(client)
     }
 
-    private func serve(_ client: Int32) {
-        switch readRequest(from: client) {
-        case .request(let request):
-            // The peer is read here and not at `accept`: resolving it costs a signature check, and a
-            // connection that never delivered a request never reaches an authorization decision.
-            // The descriptor is still the one the peer connected on, so `LOCAL_PEERTOKEN` names the
-            // process that opened it.
-            let peer = PeerIdentity.resolve(descriptor: client)
+    /// Runs on `connectionQueue` with a framed request in hand.
+    private func serve(_ request: LocalHTTPRequest, on client: Int32) {
+        // The peer is read here and not at `accept`: resolving it costs a code-signature check, and a
+        // connection that never delivered a request never reaches an authorization decision. Doing it
+        // on this queue also keeps that check off the serial read queue, where it would stall every
+        // other pending connection. The descriptor is still the one the peer connected on, so
+        // `LOCAL_PEERTOKEN` names the process that opened it.
+        //
+        // What this gives up: the window between `connect` and the identity check is as long as the
+        // request takes to arrive, so a process could write a request and then become the pinned
+        // binary. That buys nothing. The pin is a check on the binary, not on the caller, and
+        // docs/SECURITY_MODEL.md already grants that the shipped bridge plus a stolen token is a
+        // working client.
+        let peer = PeerIdentity.resolve(descriptor: client)
 
-            // Once framing is complete no more client bytes are expected. Keep watching the read
-            // side while the async handler runs so a bridge cancellation (`shutdown`) or crashed
-            // client promptly cancels the work and returns the connection slot.
-            let done = DispatchSemaphore(value: 0)
-            let cancellation = RequestCancellationState()
-            activeConnections.attach(cancellation, to: client)
-            let monitor = PeerDisconnectMonitor(descriptor: client) {
-                cancellation.cancel()
-            }
-            monitor.start()
-
-            let task = Task { [weak self] in
-                defer { done.signal() }
-                await self?.respond(to: request, on: client, peer: peer, cancellation: cancellation)
-            }
-            cancellation.attach(task)
-            done.wait()
-            cancellation.detach()
-            monitor.stopAndWait()
-        case .tooLarge(.headers):
-            send(status: 431, body: ["error": "Request headers are too large."], to: client)
-        case .tooLarge(.body):
-            send(status: 413, body: ["error": "Request body is too large."], to: client)
-        case .malformed(let reason):
-            send(status: 400, body: ["error": reason.clientMessage], to: client)
-        case .timedOut:
-            send(status: 408, body: ["error": "Timed out while reading the request."], to: client)
-        case .failed:
-            send(status: 400, body: ["error": "Could not read a complete request."], to: client)
+        // Once framing is complete no more client bytes are expected. Keep watching the read
+        // side while the async handler runs so a bridge cancellation (`shutdown`) or crashed
+        // client promptly cancels the work and returns the connection slot.
+        let done = DispatchSemaphore(value: 0)
+        let cancellation = RequestCancellationState()
+        activeConnections.attach(cancellation, to: client)
+        let monitor = PeerDisconnectMonitor(descriptor: client) {
+            cancellation.cancel()
         }
-    }
+        monitor.start()
 
-    private enum ReadOutcome {
-        case request(LocalHTTPRequest)
-        case tooLarge(LocalHTTPRequestParser.TooLargeReason)
-        case malformed(LocalHTTPRequestParser.MalformedReason)
-        case timedOut
-        case failed
-    }
-
-    private func readRequest(from client: Int32) -> ReadOutcome {
-        var buffer = Data()
-        var chunk = [UInt8](repeating: 0, count: 16 * 1_024)
-        let maximumBufferedBytes = parser.limits.maximumBufferedBytes
-        let deadline = monotonicDeadline(after: configuration.requestReadDeadline)
-
-        while true {
-            guard DispatchTime.now().uptimeNanoseconds < deadline else {
-                return .timedOut
-            }
-            switch parser.parse(buffer) {
-            case .complete(let request):
-                return .request(request)
-            case .malformed(let reason):
-                return .malformed(reason)
-            case .tooLarge(let reason):
-                return .tooLarge(reason)
-            case .incomplete:
-                break
-            }
-
-            guard buffer.count < maximumBufferedBytes else {
-                return .tooLarge(.body)
-            }
-            let remainingCapacity = maximumBufferedBytes - buffer.count
-            let readCapacity = min(chunk.count, remainingCapacity)
-            guard readCapacity > 0 else {
-                return .tooLarge(.body)
-            }
-
-            let current = DispatchTime.now().uptimeNanoseconds
-            guard current < deadline else {
-                return .timedOut
-            }
-            let remainingNanoseconds = deadline - current
-            let roundedMilliseconds = (remainingNanoseconds + 999_999) / 1_000_000
-            let pollMilliseconds = Int32(min(roundedMilliseconds, UInt64(Int32.max)))
-
-            var readiness = pollfd(
-                fd: client,
-                events: Int16(POLLIN | POLLHUP | POLLERR),
-                revents: 0
-            )
-            let ready = Darwin.poll(&readiness, 1, pollMilliseconds)
-            if ready == 0 {
-                return .timedOut
-            }
-            if ready < 0 {
-                if errno == EINTR {
-                    continue
-                }
-                return .failed
-            }
-            if readiness.revents & Int16(POLLNVAL) != 0 {
-                return .failed
-            }
-
-            let count = chunk.withUnsafeMutableBytes { raw -> Int in
-                guard let base = raw.baseAddress else { return -1 }
-                return recv(client, base, readCapacity, MSG_DONTWAIT)
-            }
-
-            if count == 0 {
-                return .failed
-            }
-            if count < 0 {
-                if errno == EINTR {
-                    continue
-                }
-                if errno == EAGAIN || errno == EWOULDBLOCK {
-                    continue
-                }
-                return .failed
-            }
-
-            buffer.append(contentsOf: chunk[0..<count])
+        let task = Task { [weak self] in
+            defer { done.signal() }
+            await self?.respond(to: request, on: client, peer: peer, cancellation: cancellation)
         }
+        cancellation.attach(task)
+        done.wait()
+        cancellation.detach()
+        monitor.stopAndWait()
     }
 
     /// Kept from the loopback era as defence in depth.

--- a/Sources/M3MCPApp/Services/LocalHTTPServer.swift
+++ b/Sources/M3MCPApp/Services/LocalHTTPServer.swift
@@ -916,7 +916,14 @@ final class LocalHTTPServer {
 
         let readSource = DispatchSource.makeReadSource(fileDescriptor: client, queue: readQueue)
         readSource.setEventHandler { [weak self] in
-            self?.readAvailable(on: connection)
+            guard let self else {
+                // The server was released with this connection still pending. Read readiness is
+                // level-triggered, so the source has to be cancelled or it would spin on EOF; its
+                // cancel handler closes the descriptor.
+                connection.readSource?.cancel()
+                return
+            }
+            self.readAvailable(on: connection)
         }
         // The single hand-off point. Cancelling is how every path leaves the read phase, so the
         // descriptor has exactly one owner at every moment and `stop()` still only shuts down.

--- a/Sources/M3MCPApp/Services/LocalHTTPServer.swift
+++ b/Sources/M3MCPApp/Services/LocalHTTPServer.swift
@@ -974,12 +974,14 @@ final class LocalHTTPServer {
             if count < 0 {
                 if errno == EINTR { continue }
                 if errno == EAGAIN || errno == EWOULDBLOCK { return }
-                finish(connection, outcome: .drop)
+                finish(connection, outcome: .reply(errorResponse(400, "Could not read a complete request.")))
                 return
             }
             if count == 0 {
-                // The peer hung up before finishing its request.
-                finish(connection, outcome: .drop)
+                // The peer hung up before finishing its request. The reply is still attempted, because
+                // a half-open client that shut down only its write side is still reading; a fully
+                // closed one drops it, which is what best-effort means.
+                finish(connection, outcome: .reply(errorResponse(400, "Could not read a complete request.")))
                 return
             }
 

--- a/Sources/M3MCPApp/Services/LocalHTTPServer.swift
+++ b/Sources/M3MCPApp/Services/LocalHTTPServer.swift
@@ -13,10 +13,18 @@ private func m3mcpFlock(_ descriptor: Int32, _ operation: Int32) -> Int32
 /// the socket replaces the former loopback TCP port. Access control is now the filesystem's job:
 /// the socket lives in a `0700` directory and is itself `0600`, so a sandboxed app — the case macOS
 /// TCC is meant to stop — cannot reach it, and neither can a web page.
+///
+/// The filesystem is only part of the access control, because it stops at the user boundary: every
+/// unsandboxed process of the same user could connect and inherit the app's Full Disk Access. So
+/// every request other than `GET /health` has to present the capability token. `SocketAuthorizer`
+/// holds the rules.
 final class LocalHTTPServer {
     typealias ToolHandler = (String, [String: JSONValue]) async -> ToolResponse
     /// `includeActivity` is false for the public health probe and true for the diagnostic endpoint.
     typealias StatusHandler = (_ includeActivity: Bool) async -> StatusResponse
+    /// Called for every authorization outcome that was refused, so a refusal is visible in the app
+    /// rather than silent.
+    typealias AuditHandler = @Sendable (AccessAttempt) -> Void
 
     struct Configuration {
         var requestLimits = LocalHTTPRequestParser.Limits()
@@ -118,8 +126,10 @@ final class LocalHTTPServer {
     }
 
     private let socketURL: URL
+    private let authorizer: SocketAuthorizer
     private let toolHandler: ToolHandler
     private let statusHandler: StatusHandler
+    private let auditHandler: AuditHandler?
     private let acceptQueue = DispatchQueue(label: "de.markzimmermann.m3mcp.accept")
     private let connectionQueue = DispatchQueue(
         label: "de.markzimmermann.m3mcp.connections",
@@ -316,20 +326,26 @@ final class LocalHTTPServer {
         }
     }
 
+    /// `authorizer` has no default on purpose. A default that let the endpoint answer without a
+    /// token would be one forgotten argument away from putting the socket back where it was.
     init(
         socketURL: URL,
+        authorizer: SocketAuthorizer,
         configuration: Configuration = Configuration(),
         socketProbeOperations: SocketProbeOperations = .live,
         toolHandler: @escaping ToolHandler,
-        statusHandler: @escaping StatusHandler
+        statusHandler: @escaping StatusHandler,
+        auditHandler: AuditHandler? = nil
     ) {
         self.socketURL = socketURL
+        self.authorizer = authorizer
         self.configuration = configuration
         self.socketProbeOperations = socketProbeOperations
         self.parser = LocalHTTPRequestParser(limits: configuration.requestLimits)
         self.connectionSlots = DispatchSemaphore(value: max(1, configuration.maximumConcurrentConnections))
         self.toolHandler = toolHandler
         self.statusHandler = statusHandler
+        self.auditHandler = auditHandler
     }
 
     deinit {
@@ -1022,9 +1038,23 @@ final class LocalHTTPServer {
         guard responseIsAllowed(cancellation) else { return }
 
         if let reason = RequestGuard.rejection(for: request) {
-            send(status: 403, body: ["error": reason], to: client, cancellation: cancellation)
+            report(request, allowed: false, reason: reason)
+            send(status: 403, refusal: reason, path: request.path, to: client, cancellation: cancellation)
             return
         }
+
+        let decision = authorizer.authorize(
+            method: request.method,
+            path: request.path,
+            authorizationHeader: request.headers["authorization"]
+        )
+        if case .deny(let status, let reason) = decision {
+            report(request, allowed: false, reason: reason)
+            send(status: status, refusal: reason, path: request.path, to: client, cancellation: cancellation)
+            return
+        }
+
+        report(request, allowed: true, reason: nil)
 
         if request.method == "GET", request.path == "/health" {
             let status = await statusHandler(false)
@@ -1063,6 +1093,35 @@ final class LocalHTTPServer {
         }
 
         send(status: 404, body: ["error": "Not found"], to: client, cancellation: cancellation)
+    }
+
+    private func report(_ request: LocalHTTPRequest, allowed: Bool, reason: String?) {
+        guard let auditHandler else { return }
+        auditHandler(
+            AccessAttempt(method: request.method, path: request.path, allowed: allowed, reason: reason)
+        )
+    }
+
+    /// A refusal on a tool path has to decode as a `ToolResponse`, because that is the only shape
+    /// `LocalAppClient` reads for statuses in `200..<500`; anything else reaches the MCP client as
+    /// "unreadable response" instead of as the reason it was refused.
+    private func send(
+        status: Int,
+        refusal: String,
+        path: String,
+        to client: Int32,
+        cancellation: RequestCancellationState? = nil
+    ) {
+        if path.hasPrefix("/tools/") {
+            send(
+                status: status,
+                codable: ToolResponse(ok: false, source: "M3MCP Server", message: refusal),
+                to: client,
+                cancellation: cancellation
+            )
+        } else {
+            send(status: status, body: ["error": refusal], to: client, cancellation: cancellation)
+        }
     }
 
     private func responseIsAllowed(_ cancellation: RequestCancellationState?) -> Bool {
@@ -1140,6 +1199,7 @@ final class LocalHTTPServer {
         switch status {
         case 200: reason = "OK"
         case 400: reason = "Bad Request"
+        case 401: reason = "Unauthorized"
         case 408: reason = "Request Timeout"
         case 403: reason = "Forbidden"
         case 404: reason = "Not Found"

--- a/Sources/M3MCPApp/Views/ContentView.swift
+++ b/Sources/M3MCPApp/Views/ContentView.swift
@@ -21,6 +21,7 @@ struct ContentView: View {
                 permissionItems: model.permissionItems,
                 permissionMessage: model.permissionMessage,
                 serverState: model.serverState,
+                authenticationSummary: model.authenticationSummary,
                 securityPolicy: model.securityPolicy,
                 onPermissions: {
                     Task {

--- a/Sources/M3MCPApp/Views/DetailView.swift
+++ b/Sources/M3MCPApp/Views/DetailView.swift
@@ -7,6 +7,7 @@ struct DetailView: View {
     let permissionItems: [DataItem]
     let permissionMessage: String?
     let serverState: String
+    let authenticationSummary: String
     let securityPolicy: M3MCPSecurityPolicy
     let onPermissions: () -> Void
     let onPermissionRefresh: () -> Void
@@ -55,6 +56,13 @@ struct DetailView: View {
                 Text("\(M3MCPEndpoint.displayPath)  \(serverState)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                // A degraded door has to be visible. Token-only, because no bridge was found next to
+                // the app, reads the same as fully pinned unless it is written down somewhere.
+                Text(authenticationSummary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
             }
 
             Spacer()

--- a/Sources/M3MCPBridge/LocalAppClient.swift
+++ b/Sources/M3MCPBridge/LocalAppClient.swift
@@ -24,21 +24,88 @@ final class LocalAppClient: @unchecked Sendable {
         attributes: .concurrent
     )
 
+    /// Resolved on the first tool call, not at start-up.
+    ///
+    /// `initialize` and `tools/list` are answered out of the catalog without ever touching the app,
+    /// and an MCP client sends them the moment it launches the bridge. Reading the keychain there
+    /// would spend the user's keychain on someone who has not asked for any data yet, and it would
+    /// break `script/check_release_artifact.sh`, which pipes `initialize` and `tools/list` into the
+    /// packaged bridge on a machine with no app, no keychain item and no token.
+    ///
+    /// The outer optional is "not looked yet", the inner one is "looked and found nothing".
+    private var credentials: CapabilityToken.Resolution??
+
+    /// Why there is no token, kept so the refusal can say it.
+    private var missingTokenReason: String?
+
+    /// `queue` is concurrent and `call` can be entered from several tasks, so the one-shot lookup
+    /// needs a lock of its own.
+    private let credentialsLock = NSLock()
+
     /// Speech recognition and transcript searches can take minutes; a short timeout would report the
     /// app as unreachable while it is still working.
+    /// `capabilityToken` is a seam for tests that drive the transport against a fixture socket, the
+    /// same way `registeredSocketHook` is. Production leaves it nil, and the token is then resolved
+    /// once, lazily, on the first tool call.
     init(
         socketURL: URL = M3MCPEndpoint.socketURL,
         timeout: TimeInterval = defaultResponseTimeout,
+        capabilityToken: String? = nil,
         registeredSocketHook: @escaping RegisteredSocketHook = { _ in }
     ) {
         self.socketURL = socketURL
         let finiteTimeout = timeout.isFinite ? timeout : Self.defaultResponseTimeout
         self.timeout = min(max(finiteTimeout, 0.001), 86_400)
         self.registeredSocketHook = registeredSocketHook
+        if let capabilityToken {
+            self.credentials = .some(
+                CapabilityToken.Resolution(token: capabilityToken, origin: "caller-supplied token")
+            )
+        }
+    }
+
+    /// Looks the token up once and keeps the answer, negative answers included: a keychain read that
+    /// was refused will be refused again, and repeating it per call would only add latency.
+    private func resolvedCredentials() -> CapabilityToken.Resolution? {
+        credentialsLock.lock()
+        defer { credentialsLock.unlock() }
+
+        if let credentials {
+            return credentials
+        }
+        switch CapabilityToken.forClient() {
+        case .resolved(let resolution):
+            credentials = .some(resolution)
+            return resolution
+        case .missing(let reason):
+            missingTokenReason = reason
+            credentials = .some(nil)
+            return nil
+        }
+    }
+
+    private func missingTokenResponse() -> ToolResponse {
+        credentialsLock.lock()
+        let reason = missingTokenReason
+        credentialsLock.unlock()
+
+        return ToolResponse(
+            ok: false,
+            source: "M3MCPBridge",
+            message: "No capability token, so M3MCPApp will refuse this call: "
+                + (reason ?? "none is configured.")
+                + " Open the M3MCP app, choose Server › Copy MCP Client Token, and add it to this "
+                + "client's configuration as \"env\": {\"\(CapabilityToken.environmentKey)\": "
+                + "\"<token>\"}. That path needs no keychain access at all."
+        )
     }
 
     func call(tool: String, arguments: [String: Any]) async -> ToolResponse {
         let path = "/tools/\(tool.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? tool)"
+
+        guard let credentials = resolvedCredentials() else {
+            return missingTokenResponse()
+        }
 
         let body: Data
         do {
@@ -62,6 +129,7 @@ final class LocalAppClient: @unchecked Sendable {
                     method: "POST",
                     path: path,
                     body: body,
+                    token: credentials.token,
                     cancellationController: cancellationController
                 )
             }, onCancel: {
@@ -125,6 +193,7 @@ final class LocalAppClient: @unchecked Sendable {
         method: String,
         path: String,
         body: Data,
+        token: String,
         cancellationController: SocketCancellationController
     ) async throws -> HTTPReply {
         try await withCheckedThrowingContinuation { continuation in
@@ -135,6 +204,7 @@ final class LocalAppClient: @unchecked Sendable {
                         method: method,
                         path: path,
                         body: body,
+                        token: token,
                         timeout: timeout,
                         cancellationController: cancellationController,
                         registeredSocketHook: registeredSocketHook
@@ -152,6 +222,7 @@ final class LocalAppClient: @unchecked Sendable {
         method: String,
         path: String,
         body: Data,
+        token: String,
         timeout: TimeInterval,
         cancellationController: SocketCancellationController,
         registeredSocketHook: RegisteredSocketHook
@@ -217,6 +288,7 @@ final class LocalAppClient: @unchecked Sendable {
         request.append(Data("\(method) \(path) HTTP/1.1\r\n".utf8))
         request.append(Data("Host: localhost\r\n".utf8))
         request.append(Data("Content-Type: application/json\r\n".utf8))
+        request.append(Data("Authorization: Bearer \(token)\r\n".utf8))
         request.append(Data("Content-Length: \(body.count)\r\n".utf8))
         request.append(Data("Connection: close\r\n\r\n".utf8))
         request.append(body)

--- a/Sources/M3MCPCore/CapabilityToken.swift
+++ b/Sources/M3MCPCore/CapabilityToken.swift
@@ -1,0 +1,293 @@
+import Foundation
+import Security
+
+/// The capability token the app hands out and the bridge presents on every tool call.
+///
+/// Until this existed the only access control on the endpoint was the filesystem: a `0600` socket
+/// in a `0700` directory. That keeps other users out and nothing else. Every unsandboxed process
+/// running as the same user could connect and inherit the app's Full Disk Access. The token turns
+/// "connect to the socket" from a capability every process of the user holds into one that has to
+/// be configured.
+///
+/// What it is not: a token stays usable when it is copied. `SocketAuthorizer` pairs it with a pin on
+/// the peer's code identity, which forces a thief through the bundled bridge rather than a client of
+/// their own. Both halves are needed and neither is sufficient.
+///
+/// Where it lives: the login keychain, as a generic password. That is a deliberate choice over a
+/// `0600` file next to the socket. Such a file would be readable by exactly the set of processes
+/// that can already open the socket, so it would add nothing. A keychain item is bound by its ACL to
+/// the binary that created it, and reaching it from anywhere else takes the user's say-so.
+///
+/// The cost changed for the better on this branch's base. `script/install_local.sh` and
+/// `script/package_release.sh` both sign with a stable certificate and say why: an ad-hoc signature
+/// puts the binary hash into the designated requirement, so every rebuild would silently invalidate
+/// the Full Disk Access grant. The keychain ACL is bound the same way, so it survives a rebuild for
+/// the same reason the TCC grant does. What does not change is that the bridge is a second binary:
+/// it does not prompt, because the panel would appear in a session an MCP client has not got — see
+/// `read(service:account:allowingInteraction:)`. So the fallback reaches an item already on this
+/// bridge's ACL and no other, and a client that is not that has to be given `M3MCP_TOKEN`.
+public enum CapabilityToken {
+    /// Set this and it wins over the keychain, in the app and in the bridge alike.
+    ///
+    /// This is how an MCP client is configured (`"env": {"M3MCP_TOKEN": "…"}`) and how the tests run
+    /// without touching a keychain that may not be unlocked.
+    public static let environmentKey = "M3MCP_TOKEN"
+
+    /// Lets a test — or a second installation — use its own keychain item instead of the real one.
+    public static let serviceEnvironmentKey = "M3MCP_TOKEN_KEYCHAIN_SERVICE"
+
+    public static let defaultService = "de.markzimmermann.m3mcp.capability-token"
+    public static let defaultAccount = "default"
+
+    /// A token plus where it came from, so the app can say so in its UI and the bridge in its errors.
+    public struct Resolution: Sendable, Equatable {
+        public let token: String
+        public let origin: String
+
+        public init(token: String, origin: String) {
+            self.token = token
+            self.origin = origin
+        }
+    }
+
+    public enum Failure: LocalizedError {
+        case keychain(OSStatus, String)
+        case randomness(Int32)
+
+        public var errorDescription: String? {
+            switch self {
+            case .keychain(let status, let operation):
+                let text = SecCopyErrorMessageString(status, nil) as String? ?? "OSStatus \(status)"
+                return "Keychain \(operation) failed: \(text) (\(status))"
+            case .randomness(let status):
+                return "Could not read random bytes for a new token (SecRandomCopyBytes: \(status))"
+            }
+        }
+    }
+
+    public static var service: String {
+        let override = ProcessInfo.processInfo.environment[serviceEnvironmentKey] ?? ""
+        return override.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? defaultService : override
+    }
+
+    // MARK: - App side
+
+    /// The token the server enforces. Generated and stored on first start.
+    public static func loadOrCreate(service: String? = nil, account: String = defaultAccount) throws -> Resolution {
+        if let fromEnvironment = environmentToken() {
+            return Resolution(token: fromEnvironment, origin: "\(environmentKey) environment variable")
+        }
+
+        let service = service ?? self.service
+        if let stored = try read(service: service, account: account) {
+            return Resolution(token: stored, origin: "keychain item \(service)")
+        }
+
+        let token = try generate()
+        try write(token: token, service: service, account: account)
+        return Resolution(token: token, origin: "keychain item \(service), created on this start")
+    }
+
+    // MARK: - Client side
+
+    /// What a client found, and when it found nothing, why.
+    ///
+    /// The reason matters because the two ways of finding nothing want different fixes: no item at
+    /// all means the app has not run yet, while a refused item means this binary is not the one that
+    /// created it and the token belongs in the client's configuration instead.
+    public enum ClientToken: Sendable {
+        case resolved(Resolution)
+        case missing(reason: String)
+
+        public var resolution: Resolution? {
+            if case .resolved(let value) = self { return value }
+            return nil
+        }
+    }
+
+    /// The token a client presents. Never creates one: a client that invents a token would only ever
+    /// be refused, and the error should say what to configure.
+    ///
+    /// The keychain read here refuses interaction on purpose. An MCP client starts the bridge with
+    /// no window session of its own, and a keychain item created by another binary — which the app's
+    /// item is, from the bridge's point of view — otherwise puts up an authorization panel: measured
+    /// on a bridge started from a shell, `SecItemCopyMatching` had not returned after 25 seconds and
+    /// nothing had been printed. To the MCP client that is a server that never answers.
+    /// Refusing interaction turns that into an immediate error, and the message says to put the
+    /// token in the client's configuration.
+    public static func forClient(service: String? = nil, account: String = defaultAccount) -> ClientToken {
+        if let fromEnvironment = environmentToken() {
+            return .resolved(Resolution(token: fromEnvironment, origin: "\(environmentKey) environment variable"))
+        }
+
+        let service = service ?? self.service
+        do {
+            if let stored = try read(service: service, account: account, allowingInteraction: false) {
+                return .resolved(Resolution(token: stored, origin: "keychain item \(service)"))
+            }
+            return .missing(
+                reason: "there is no keychain item \(service). The M3MCP app creates it on its first start."
+            )
+        } catch CapabilityToken.Failure.keychain(let status, _)
+            where status == errSecInteractionNotAllowed || status == errSecAuthFailed
+                || status == errSecUserCanceled {
+            // errSecAuthFailed is what the file-based keychain returns for "I would have asked, and
+            // I was told not to". It reads like a wrong password and means a refused ACL.
+            return .missing(
+                reason: "the keychain item \(service) exists, but this binary may not read it without asking "
+                    + "you first, and a bridge started by an MCP client has no way to ask."
+            )
+        } catch {
+            return .missing(reason: error.localizedDescription)
+        }
+    }
+
+    /// The token a client presents, or nil when none is configured.
+    public static func existing(service: String? = nil, account: String = defaultAccount) -> Resolution? {
+        forClient(service: service, account: account).resolution
+    }
+
+    // MARK: - Primitives
+
+    /// 32 bytes from the system CSPRNG, base64url without padding, so it survives an environment
+    /// variable, a JSON config file and an HTTP header untouched.
+    public static func generate() throws -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw Failure.randomness(status)
+        }
+
+        return Data(bytes)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    /// Comparison in time that does not depend on how many leading characters match.
+    ///
+    /// The length is allowed to leak — it is fixed by `generate()` — but the contents are not.
+    public static func matches(_ presented: String, _ expected: String) -> Bool {
+        let left = Array(presented.utf8)
+        let right = Array(expected.utf8)
+        guard !right.isEmpty, left.count == right.count else {
+            return false
+        }
+
+        var difference: UInt8 = 0
+        for index in 0..<right.count {
+            difference |= left[index] ^ right[index]
+        }
+        return difference == 0
+    }
+
+    // MARK: - Keychain
+
+    /// `allowingInteraction: false` is what keeps a read bounded.
+    ///
+    /// Without it `SecItemCopyMatching` waits for the authorization panel with no deadline of its
+    /// own. That is right in an app with a window and is a hang anywhere else — measured on the
+    /// bridge reading an item another binary created: no answer after 25 seconds and nothing on
+    /// stdout, which an MCP client sees as a server that never replies.
+    ///
+    /// What does the bounding is `SecKeychainSetUserInteractionAllowed`, deprecated since 10.10 and
+    /// still the only thing that works here. `kSecUseAuthenticationUI` was tried first and measured:
+    /// with `…UIFail` and with `…UISkip` alike the call still had not returned after 20 seconds,
+    /// because those govern the modern authentication path and not the ACL prompt of the file-based
+    /// login keychain, which is the keychain an app without entitlements gets. With the legacy switch
+    /// the same read comes back in 15 milliseconds as `errSecAuthFailed`.
+    ///
+    /// The switch is process-wide, so the previous value goes back before returning.
+    public static func read(
+        service: String,
+        account: String,
+        allowingInteraction: Bool = true
+    ) throws -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var item: CFTypeRef?
+        let status = allowingInteraction
+            ? SecItemCopyMatching(query as CFDictionary, &item)
+            : copyWithoutInteraction(query, into: &item)
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data, let token = String(data: data, encoding: .utf8) else {
+                return nil
+            }
+            return token
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw Failure.keychain(status, "read")
+        }
+    }
+
+    public static func write(token: String, service: String, account: String) throws {
+        let data = Data(token.utf8)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+
+        var attributes = query
+        attributes[kSecValueData as String] = data
+        attributes[kSecAttrLabel as String] = "M3MCP capability token"
+        attributes[kSecAttrDescription as String] = "Authenticates an MCP client against the local M3MCP socket"
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlocked
+
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        switch status {
+        case errSecSuccess:
+            return
+        case errSecDuplicateItem:
+            let update = SecItemUpdate(query as CFDictionary, [kSecValueData as String: data] as CFDictionary)
+            guard update == errSecSuccess else {
+                throw Failure.keychain(update, "update")
+            }
+        default:
+            throw Failure.keychain(status, "write")
+        }
+    }
+
+    public static func delete(service: String, account: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw Failure.keychain(status, "delete")
+        }
+    }
+
+    /// The one place the deprecated switch is touched, and deprecated itself so the warning lands
+    /// here, once, next to the explanation instead of three times inside it.
+    @available(
+        macOS,
+        deprecated: 10.10,
+        message: "SecKeychainSetUserInteractionAllowed has no replacement that covers the file-based login keychain. Measured, not assumed: see read(service:account:allowingInteraction:)."
+    )
+    private static func copyWithoutInteraction(_ query: [String: Any], into item: inout CFTypeRef?) -> OSStatus {
+        var wasAllowed: DarwinBoolean = true
+        _ = SecKeychainGetUserInteractionAllowed(&wasAllowed)
+        _ = SecKeychainSetUserInteractionAllowed(false)
+        defer { _ = SecKeychainSetUserInteractionAllowed(wasAllowed.boolValue) }
+        return SecItemCopyMatching(query as CFDictionary, &item)
+    }
+
+    private static func environmentToken() -> String? {
+        let raw = ProcessInfo.processInfo.environment[environmentKey] ?? ""
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Sources/M3MCPCore/LocalEndpoint.swift
+++ b/Sources/M3MCPCore/LocalEndpoint.swift
@@ -7,6 +7,11 @@ import Foundation
 /// from reading the data the app re-exposes. A socket file makes the boundary a filesystem one:
 /// the directory is `0700` and the socket is `0600`, so only the user's own unsandboxed processes
 /// can connect, and a web page cannot reach it at all.
+///
+/// Those permissions are the outer layer, not the whole of it. "the user's own unsandboxed
+/// processes" is a large set, and every one of them used to inherit the app's Full Disk Access by
+/// connecting. `SocketAuthorizer` now requires a capability token on everything but `GET /health`,
+/// and `PeerIdentity` checks which binary is on the other end.
 public enum M3MCPEndpoint {
     /// `sockaddr_un.sun_path` is 104 bytes on Darwin, including the terminator.
     public static let maximumSocketPathLength = 103

--- a/Sources/M3MCPCore/PeerIdentity.swift
+++ b/Sources/M3MCPCore/PeerIdentity.swift
@@ -1,0 +1,219 @@
+import Darwin
+import Foundation
+import Security
+
+/// Who is on the other end of an accepted Unix-socket connection.
+///
+/// Why this exists: the capability token answers "is this client configured?" and nothing more. It is
+/// a secret in a configuration file, so a copy of it works. Checking `getpeereid` would add nothing
+/// on top: it tests the condition the kernel already enforced when it let the `connect` through, and
+/// it would read as security that is not there.
+///
+/// What does carry weight on macOS is the peer's *code* identity. `LOCAL_PEERTOKEN` hands the
+/// listener the audit token of the connecting process, and the Security framework turns that token
+/// into a `SecCode` whose signature can be checked and whose code directory hash can be read. The
+/// hash is over the binary's own pages: another process cannot present it without being that binary.
+///
+/// The audit token is used in preference to the pid because a pid can be recycled between the
+/// `accept` and the lookup, and the token identifies one specific process instance. That window is
+/// not theoretical here: a connection stays open through an asynchronous tool call that may run for
+/// minutes, watched by `PeerDisconnectMonitor`.
+///
+/// Why the code directory hash rather than a team identifier or a certificate, measured on this
+/// branch's base:
+///
+///  * `swift build` produces an ad-hoc signature. `codesign -dvvv .build/debug/M3MCPBridge` reports
+///    `flags=0x2(adhoc)`, `TeamIdentifier=not set`, and a designated requirement that is literally
+///    `cdhash H"…"`. For the development path there is no other identity to pin.
+///  * `script/install_local.sh` and `script/package_release.sh` do sign with a stable certificate,
+///    and say why: an ad-hoc designated requirement carries the binary hash, so every rebuild would
+///    invalidate the app's Full Disk Access grant. A leaf-certificate pin is therefore possible for
+///    an installed build. It would also be weaker: `script/create_local_identity.sh` creates one
+///    self-signed `M3MCP Local Development` certificate in the login keychain, and that certificate
+///    signs every binary its owner signs, a hand-written socket client included. Pinning it would
+///    admit exactly the client the pin exists to keep out.
+///  * A hash pin does not go stale, because it is not a constant. `TrustedClient` reads it at every
+///    server start from the `M3MCPBridge` sitting next to the app's own executable, and an install
+///    replaces both files together.
+public struct PeerIdentity: Sendable, Equatable {
+    public let processIdentifier: pid_t
+    public let userIdentifier: uid_t
+
+    /// `kSecCodeInfoIdentifier` — the signing identifier, e.g. `M3MCPBridge`. Weak on its own:
+    /// anyone can ad-hoc sign a binary under any identifier. Useful for logs and messages.
+    public let signingIdentifier: String?
+
+    /// `kSecCodeInfoUnique`, lowercase hex — the code directory hash. This is the part worth pinning.
+    public let codeDirectoryHash: String?
+
+    public let executablePath: String?
+
+    /// `SecCodeCheckValidity` succeeded: the running code still matches what was signed.
+    public let signatureValid: Bool
+
+    /// Why the identity is incomplete, when it is. Nil when everything resolved.
+    public let note: String?
+
+    public init(
+        processIdentifier: pid_t,
+        userIdentifier: uid_t,
+        signingIdentifier: String? = nil,
+        codeDirectoryHash: String? = nil,
+        executablePath: String? = nil,
+        signatureValid: Bool = false,
+        note: String? = nil
+    ) {
+        self.processIdentifier = processIdentifier
+        self.userIdentifier = userIdentifier
+        self.signingIdentifier = signingIdentifier
+        self.codeDirectoryHash = codeDirectoryHash
+        self.executablePath = executablePath
+        self.signatureValid = signatureValid
+        self.note = note
+    }
+
+    /// One line for a log or an activity entry. Never carries the token.
+    public var description: String {
+        var parts = ["pid \(processIdentifier)", "uid \(userIdentifier)"]
+        if let signingIdentifier { parts.append("id \(signingIdentifier)") }
+        if let codeDirectoryHash { parts.append("cdhash \(codeDirectoryHash.prefix(12))…") }
+        if let executablePath { parts.append(executablePath) }
+        if !signatureValid { parts.append("unverified signature") }
+        if let note { parts.append(note) }
+        return parts.joined(separator: ", ")
+    }
+
+    // MARK: - Resolution
+
+    /// Reads the peer of an accepted socket. Never throws: an identity that could not be resolved is
+    /// still reported, with `note` saying what failed, so the caller can decide whether to refuse.
+    public static func resolve(descriptor: Int32) -> PeerIdentity {
+        var uid: uid_t = 0
+        var gid: gid_t = 0
+        if getpeereid(descriptor, &uid, &gid) != 0 {
+            uid = uid_t.max
+        }
+
+        var pid: pid_t = -1
+        var pidSize = socklen_t(MemoryLayout<pid_t>.size)
+        _ = withUnsafeMutablePointer(to: &pid) { pointer in
+            getsockopt(descriptor, SOL_LOCAL, LOCAL_PEERPID, pointer, &pidSize)
+        }
+
+        guard let auditToken = auditToken(of: descriptor) else {
+            return PeerIdentity(
+                processIdentifier: pid,
+                userIdentifier: uid,
+                note: "LOCAL_PEERTOKEN is unavailable on this socket, so the peer's code identity could not be read"
+            )
+        }
+
+        var code: SecCode?
+        let attributes = [kSecGuestAttributeAudit as String: auditToken] as CFDictionary
+        let guestStatus = SecCodeCopyGuestWithAttributes(nil, attributes, SecCSFlags(rawValue: 0), &code)
+        guard guestStatus == errSecSuccess, let code else {
+            return PeerIdentity(
+                processIdentifier: pid,
+                userIdentifier: uid,
+                note: "the peer has no code identity (SecCodeCopyGuestWithAttributes: \(guestStatus))"
+            )
+        }
+
+        // Dynamic validity, not just "it is signed": this fails when the pages on disk were changed
+        // after signing, which is the case a hash pin alone would not catch.
+        let validity = SecCodeCheckValidity(code, SecCSFlags(rawValue: 0), nil)
+
+        var staticCode: SecStaticCode?
+        SecCodeCopyStaticCode(code, SecCSFlags(rawValue: 0), &staticCode)
+
+        var identifier: String?
+        var hash: String?
+        var path: String?
+
+        if let staticCode {
+            var information: CFDictionary?
+            if SecCodeCopySigningInformation(staticCode, SecCSFlags(rawValue: 0), &information) == errSecSuccess,
+               let dictionary = information as? [String: Any] {
+                identifier = dictionary[kSecCodeInfoIdentifier as String] as? String
+                hash = (dictionary[kSecCodeInfoUnique as String] as? Data).map(hexadecimal)
+            }
+
+            var url: CFURL?
+            if SecCodeCopyPath(staticCode, SecCSFlags(rawValue: 0), &url) == errSecSuccess {
+                path = (url as URL?)?.path
+            }
+        }
+
+        return PeerIdentity(
+            processIdentifier: pid,
+            userIdentifier: uid,
+            signingIdentifier: identifier,
+            codeDirectoryHash: hash,
+            executablePath: path,
+            signatureValid: validity == errSecSuccess,
+            note: validity == errSecSuccess ? nil : "SecCodeCheckValidity failed (\(validity))"
+        )
+    }
+
+    /// The code directory hash of a binary on disk, in the same form `codeDirectoryHash` reports.
+    ///
+    /// Used to work out what to pin: the app hashes the `M3MCPBridge` next to its own executable and
+    /// accepts connections from that binary and no other.
+    public static func codeDirectoryHash(ofFileAt url: URL) -> String? {
+        var staticCode: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(url as CFURL, SecCSFlags(rawValue: 0), &staticCode) == errSecSuccess,
+              let staticCode
+        else {
+            return nil
+        }
+
+        return codeDirectoryHash(ofStaticCode: staticCode)
+    }
+
+    /// The hash of the calling process, so a test — or a diagnostic — can pin itself.
+    public static func codeDirectoryHashOfCurrentProcess() -> String? {
+        var code: SecCode?
+        guard SecCodeCopySelf(SecCSFlags(rawValue: 0), &code) == errSecSuccess, let code else {
+            return nil
+        }
+
+        var staticCode: SecStaticCode?
+        guard SecCodeCopyStaticCode(code, SecCSFlags(rawValue: 0), &staticCode) == errSecSuccess,
+              let staticCode
+        else {
+            return nil
+        }
+
+        return codeDirectoryHash(ofStaticCode: staticCode)
+    }
+
+    // MARK: - Internals
+
+    private static func codeDirectoryHash(ofStaticCode staticCode: SecStaticCode) -> String? {
+        var information: CFDictionary?
+        guard SecCodeCopySigningInformation(staticCode, SecCSFlags(rawValue: 0), &information) == errSecSuccess,
+              let dictionary = information as? [String: Any],
+              let data = dictionary[kSecCodeInfoUnique as String] as? Data
+        else {
+            return nil
+        }
+
+        return hexadecimal(data)
+    }
+
+    private static func auditToken(of descriptor: Int32) -> Data? {
+        var token = audit_token_t()
+        var size = socklen_t(MemoryLayout<audit_token_t>.size)
+        let result = withUnsafeMutablePointer(to: &token) { pointer in
+            getsockopt(descriptor, SOL_LOCAL, LOCAL_PEERTOKEN, pointer, &size)
+        }
+        guard result == 0, size == socklen_t(MemoryLayout<audit_token_t>.size) else {
+            return nil
+        }
+        return withUnsafeBytes(of: &token) { Data($0) }
+    }
+
+    private static func hexadecimal(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/M3MCPCore/SocketAuthorizer.swift
+++ b/Sources/M3MCPCore/SocketAuthorizer.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Decides whether an accepted connection may do what it is asking to do.
+///
+/// The **capability token** answers "is this client configured?". Missing or wrong is `401`.
+///
+/// What is deliberately *not* checked: the peer's uid. The socket is `0600` inside a `0700`
+/// directory, so the kernel refused every other uid before this code ran. Testing it here would
+/// restate a condition already enforced and would read as security that is not there.
+public struct SocketAuthorizer: Sendable {
+    public enum Decision: Sendable, Equatable {
+        case allow
+        case deny(status: Int, reason: String)
+
+        public var isAllowed: Bool {
+            if case .allow = self { return true }
+            return false
+        }
+    }
+
+    /// The token every non-public request must present as `Authorization: Bearer <token>`.
+    public let token: String
+
+    public init(token: String) {
+        self.token = token
+    }
+
+    /// One line for the app UI and for `/health`, so a degraded install is visible rather than quiet.
+    public var pinningDescription: String {
+        "token only"
+    }
+
+    /// `/health` is the one path that answers without a token: it is the documented probe that
+    /// `script/install_local.sh` waits on, and `AppModel` keeps the activity log out of it by
+    /// answering it with `statusResponse(includeActivity: false)`.
+    ///
+    /// `/status` is not public. It carries up to 30 recent activity entries with tool inputs and
+    /// bounded outputs, which is the most sensitive thing the endpoint can hand out.
+    public static func isPublic(method: String, path: String) -> Bool {
+        method == "GET" && path == "/health"
+    }
+
+    public func authorize(
+        method: String,
+        path: String,
+        authorizationHeader: String?
+    ) -> Decision {
+        if Self.isPublic(method: method, path: path) {
+            return .allow
+        }
+
+        guard let presented = Self.bearerToken(in: authorizationHeader) else {
+            return .deny(
+                status: 401,
+                reason: "This endpoint needs a capability token. Send 'Authorization: Bearer <token>'. "
+                    + "M3MCPBridge reads the token from \(CapabilityToken.environmentKey) or from the "
+                    + "login keychain; the M3MCP app shows it under Server."
+            )
+        }
+
+        guard CapabilityToken.matches(presented, token) else {
+            return .deny(status: 401, reason: "The capability token is not the one this M3MCP instance issued.")
+        }
+
+        return .allow
+    }
+
+    /// Case-insensitive on the scheme, because HTTP auth schemes are.
+    public static func bearerToken(in header: String?) -> String? {
+        guard let header else { return nil }
+        let trimmed = header.trimmingCharacters(in: .whitespaces)
+        let parts = trimmed.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+        guard parts.count == 2, parts[0].lowercased() == "bearer" else { return nil }
+        let value = parts[1].trimmingCharacters(in: .whitespaces)
+        return value.isEmpty ? nil : value
+    }
+}
+
+/// One authorization outcome, for the log and for the app's activity list.
+public struct AccessAttempt: Sendable {
+    public let method: String
+    public let path: String
+    public let allowed: Bool
+    public let reason: String?
+
+    public init(method: String, path: String, allowed: Bool, reason: String? = nil) {
+        self.method = method
+        self.path = path
+        self.allowed = allowed
+        self.reason = reason
+    }
+}

--- a/Sources/M3MCPCore/SocketAuthorizer.swift
+++ b/Sources/M3MCPCore/SocketAuthorizer.swift
@@ -2,7 +2,16 @@ import Foundation
 
 /// Decides whether an accepted connection may do what it is asking to do.
 ///
-/// The **capability token** answers "is this client configured?". Missing or wrong is `401`.
+/// Two factors, and they fail differently on purpose:
+///
+///  * the **capability token** answers "is this client configured?". Missing or wrong is `401`.
+///  * the **pinned code identity** answers "is this the client I was configured for?". A valid token
+///    from the wrong binary is `403`, so a socket client somebody writes themselves does not get in
+///    on a copied token alone.
+///
+/// What the pin is not: proof of who is calling. It identifies the binary on the other end, and the
+/// bundled `M3MCPBridge` satisfies it whichever process starts it. A stolen token plus that bridge
+/// is still a working client — see Known limits in docs/SECURITY_MODEL.md.
 ///
 /// What is deliberately *not* checked: the peer's uid. The socket is `0600` inside a `0700`
 /// directory, so the kernel refused every other uid before this code ran. Testing it here would
@@ -21,13 +30,31 @@ public struct SocketAuthorizer: Sendable {
     /// The token every non-public request must present as `Authorization: Bearer <token>`.
     public let token: String
 
-    public init(token: String) {
+    /// Code directory hashes that may connect. Empty means pinning is off — see `pinningDescription`.
+    public let trustedCodeDirectoryHashes: Set<String>
+
+    /// Where the pin came from, in words. It goes into the refusal, because the likely cause of a
+    /// `403` is a client pointed at a second copy of the bridge, and the message should name the copy
+    /// that would work.
+    public let trustDescription: String
+
+    public init(
+        token: String,
+        trustedCodeDirectoryHashes: Set<String> = [],
+        trustDescription: String = ""
+    ) {
         self.token = token
+        self.trustedCodeDirectoryHashes = Set(trustedCodeDirectoryHashes.map { $0.lowercased() })
+        self.trustDescription = trustDescription
     }
+
+    public var pinsPeerIdentity: Bool { !trustedCodeDirectoryHashes.isEmpty }
 
     /// One line for the app UI and for `/health`, so a degraded install is visible rather than quiet.
     public var pinningDescription: String {
-        "token only"
+        pinsPeerIdentity
+            ? "token + pinned client (\(trustedCodeDirectoryHashes.count) code hash(es))"
+            : "token only — no M3MCPBridge found next to the app, so the client binary is not pinned"
     }
 
     /// `/health` is the one path that answers without a token: it is the documented probe that
@@ -43,7 +70,8 @@ public struct SocketAuthorizer: Sendable {
     public func authorize(
         method: String,
         path: String,
-        authorizationHeader: String?
+        authorizationHeader: String?,
+        peer: PeerIdentity
     ) -> Decision {
         if Self.isPublic(method: method, path: path) {
             return .allow
@@ -60,6 +88,29 @@ public struct SocketAuthorizer: Sendable {
 
         guard CapabilityToken.matches(presented, token) else {
             return .deny(status: 401, reason: "The capability token is not the one this M3MCP instance issued.")
+        }
+
+        guard pinsPeerIdentity else {
+            return .allow
+        }
+
+        guard peer.signatureValid, let hash = peer.codeDirectoryHash else {
+            return .deny(
+                status: 403,
+                reason: "The connecting process has no verifiable code signature, so it cannot be matched "
+                    + "against the pinned client. Peer: \(peer.description)."
+            )
+        }
+
+        guard trustedCodeDirectoryHashes.contains(hash.lowercased()) else {
+            return .deny(
+                status: 403,
+                reason: "The token is valid, but it was presented by a process this instance is not "
+                    + "configured for. Only the M3MCPBridge that ships with this app may connect"
+                    + (trustDescription.isEmpty ? "" : " (\(trustDescription))")
+                    + ". A second copy of the same bridge built elsewhere has a different code "
+                    + "directory hash and is refused. Peer: \(peer.description)."
+            )
         }
 
         return .allow
@@ -80,12 +131,14 @@ public struct SocketAuthorizer: Sendable {
 public struct AccessAttempt: Sendable {
     public let method: String
     public let path: String
+    public let peer: PeerIdentity
     public let allowed: Bool
     public let reason: String?
 
-    public init(method: String, path: String, allowed: Bool, reason: String? = nil) {
+    public init(method: String, path: String, peer: PeerIdentity, allowed: Bool, reason: String? = nil) {
         self.method = method
         self.path = path
+        self.peer = peer
         self.allowed = allowed
         self.reason = reason
     }

--- a/Sources/M3MCPCore/TrustedClient.swift
+++ b/Sources/M3MCPCore/TrustedClient.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Works out which client binary this installation will accept.
+///
+/// There is no pairing dialog, so the answer has to come from something the installation already
+/// knows for certain: the `M3MCPBridge` that sits next to the app's own executable. That holds in
+/// both places the app ever runs from — `.build/<config>/` for a source build and
+/// `M3MCP.app/Contents/MacOS/` for the installed and the packaged bundle — and it is exactly the
+/// binary the README tells an MCP client to launch.
+///
+/// Reading it at every start is what keeps a hash pin from going stale: `script/install_local.sh`
+/// and `script/package_release.sh` replace app and bridge together, so the next start pins the
+/// bridge that was just installed.
+///
+/// When there is no sibling bridge the pin cannot be computed, and this says so rather than
+/// pretending. The app then runs token-only, and `/health` and the app window both report it.
+public enum TrustedClient {
+    /// Overrides the sibling lookup with an explicit list of code directory hashes, comma-separated.
+    ///
+    /// For a client that lives somewhere else, and for tests. Setting it does not weaken anything an
+    /// attacker could exploit: it is read from the *server's* environment, which only the person
+    /// starting the server controls.
+    public static let environmentKey = "M3MCP_TRUSTED_CLIENT_CDHASH"
+
+    public static let bridgeExecutableName = "M3MCPBridge"
+
+    public struct Resolution: Sendable {
+        public let hashes: Set<String>
+        public let note: String
+
+        public init(hashes: Set<String>, note: String) {
+            self.hashes = hashes
+            self.note = note
+        }
+    }
+
+    public static func resolve(appExecutableURL: URL?) -> Resolution {
+        if let raw = ProcessInfo.processInfo.environment[environmentKey] {
+            let hashes = Set(
+                raw.split(separator: ",")
+                    .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+                    .filter { !$0.isEmpty }
+            )
+            if !hashes.isEmpty {
+                return Resolution(hashes: hashes, note: "pinned from \(environmentKey)")
+            }
+        }
+
+        guard let appExecutableURL else {
+            return Resolution(
+                hashes: [],
+                note: "the app could not determine its own executable path, so the client binary is not pinned"
+            )
+        }
+
+        let bridge = appExecutableURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(bridgeExecutableName, isDirectory: false)
+
+        guard FileManager.default.isExecutableFile(atPath: bridge.path) else {
+            return Resolution(
+                hashes: [],
+                note: "no \(bridgeExecutableName) next to \(appExecutableURL.lastPathComponent), "
+                    + "so the client binary is not pinned"
+            )
+        }
+
+        guard let hash = PeerIdentity.codeDirectoryHash(ofFileAt: bridge) else {
+            return Resolution(
+                hashes: [],
+                note: "\(bridge.path) has no readable code signature, so the client binary is not pinned"
+            )
+        }
+
+        return Resolution(hashes: [hash], note: "pinned to \(bridge.path)")
+    }
+}

--- a/Tests/Installer/install_local_readiness_test.sh
+++ b/Tests/Installer/install_local_readiness_test.sh
@@ -31,9 +31,15 @@ setup_case() {
 
   printf 'old-app\n' > "$CASE_INSTALL_DIR/M3MCP.app/Contents/MacOS/M3MCPApp"
   chmod +x "$CASE_INSTALL_DIR/M3MCP.app/Contents/MacOS/M3MCPApp"
+  printf 'old-bridge\n' > "$CASE_INSTALL_DIR/M3MCP.app/Contents/MacOS/M3MCPBridge"
+  chmod +x "$CASE_INSTALL_DIR/M3MCP.app/Contents/MacOS/M3MCPBridge"
   printf 'old-agent\n' > "$CASE_HOME/Library/LaunchAgents/de.markzimmermann.m3mcp.plist"
   printf '#!/bin/sh\nexit 0\n# new-app\n' > "$CASE_BUILD_DIR/M3MCPApp"
   chmod +x "$CASE_BUILD_DIR/M3MCPApp"
+  # The app pins the client to the bridge next to its own executable, so the installer must stage,
+  # sign, and commit both together.
+  printf '#!/bin/sh\nexit 0\n# new-bridge\n' > "$CASE_BUILD_DIR/M3MCPBridge"
+  chmod +x "$CASE_BUILD_DIR/M3MCPBridge"
 
   cat > "$CASE_MOCK_BIN/mock-command" <<'MOCK'
 #!/usr/bin/env bash
@@ -126,6 +132,8 @@ test_live_path_verification_failure_stops_replacement_before_rollback() {
   [[ "$CASE_STATUS" -ne 0 ]] || fail "live replacement verification failure committed"
   [[ "$(<"$CASE_INSTALL_DIR/M3MCP.app/Contents/MacOS/M3MCPApp")" == "old-app" ]] \
     || fail "previous app was not restored after live-path failure"
+  [[ "$(<"$CASE_INSTALL_DIR/M3MCP.app/Contents/MacOS/M3MCPBridge")" == "old-bridge" ]] \
+    || fail "previous bridge was not restored after live-path failure"
   [[ "$(<"$CASE_HOME/Library/LaunchAgents/de.markzimmermann.m3mcp.plist")" == "old-agent" ]] \
     || fail "previous agent changed during live-path failure"
   [[ "$(grep -c '^launchctl bootout ' "$CASE_COMMAND_LOG")" == "1" ]] \
@@ -155,6 +163,8 @@ test_unhealthy_response_rolls_back() {
   [[ "$CASE_STATUS" -ne 0 ]] || fail "an unhealthy /health response committed the installation"
   [[ "$(<"$CASE_INSTALL_DIR/M3MCP.app/Contents/MacOS/M3MCPApp")" == "old-app" ]] \
     || fail "previous application was not restored"
+  [[ "$(<"$CASE_INSTALL_DIR/M3MCP.app/Contents/MacOS/M3MCPBridge")" == "old-bridge" ]] \
+    || fail "previous bridge was not restored"
   [[ "$(<"$CASE_HOME/Library/LaunchAgents/de.markzimmermann.m3mcp.plist")" == "old-agent" ]] \
     || fail "previous LaunchAgent was not restored"
   [[ "$(<"$CASE_CURL_COUNT")" == "40" ]] \
@@ -178,6 +188,12 @@ test_health_success_commits_after_retry() {
   [[ "$CASE_STATUS" -eq 0 ]] || fail "healthy replacement did not commit"
   grep -Fq '# new-app' "$CASE_INSTALL_DIR/M3MCP.app/Contents/MacOS/M3MCPApp" \
     || fail "replacement application was not retained"
+  grep -Fq '# new-bridge' "$CASE_INSTALL_DIR/M3MCP.app/Contents/MacOS/M3MCPBridge" \
+    || fail "replacement bridge was not installed next to the app, so the client pin would be off"
+  grep -Fq 'codesign --force --sign' "$CASE_COMMAND_LOG" \
+    || fail "nothing was signed"
+  [[ "$(grep -c '^codesign --force --sign .*/M3MCPBridge$' "$CASE_COMMAND_LOG")" == "1" ]] \
+    || fail "the staged bridge was not signed exactly once"
   grep -Fq '<key>Label</key>' "$CASE_HOME/Library/LaunchAgents/de.markzimmermann.m3mcp.plist" \
     || fail "replacement LaunchAgent was not retained"
   [[ "$(<"$CASE_CURL_COUNT")" == "3" ]] \

--- a/Tests/M3MCPAppTests/LocalHTTPServerCancellationTests.swift
+++ b/Tests/M3MCPAppTests/LocalHTTPServerCancellationTests.swift
@@ -37,6 +37,7 @@ final class LocalHTTPServerCancellationTests: XCTestCase {
 
         let server = LocalHTTPServer(
             socketURL: socketURL,
+            authorizer: SocketAuthorizer(token: testCapabilityToken),
             configuration: configuration,
             toolHandler: { _, _ in
                 handlerStarted.fulfill()
@@ -68,7 +69,7 @@ final class LocalHTTPServerCancellationTests: XCTestCase {
         defer { Darwin.close(client) }
         try writeAll(
             Data(
-                "POST /tools/source_status HTTP/1.1\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n{}".utf8
+                "POST /tools/source_status HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Bearer \(testCapabilityToken)\r\nContent-Length: 2\r\n\r\n{}".utf8
             ),
             to: client
         )
@@ -106,6 +107,7 @@ final class LocalHTTPServerCancellationTests: XCTestCase {
 
         let server = LocalHTTPServer(
             socketURL: socketURL,
+            authorizer: SocketAuthorizer(token: testCapabilityToken),
             configuration: configuration,
             toolHandler: { _, _ in
                 ToolResponse(ok: true, source: "test", message: "unexpected dispatch")
@@ -169,6 +171,7 @@ final class LocalHTTPServerCancellationTests: XCTestCase {
 
         let server = LocalHTTPServer(
             socketURL: socketURL,
+            authorizer: SocketAuthorizer(token: testCapabilityToken),
             configuration: configuration,
             toolHandler: { _, _ in
                 ToolResponse(ok: true, source: "test", message: "unexpected dispatch")
@@ -232,6 +235,7 @@ final class LocalHTTPServerCancellationTests: XCTestCase {
 
         let server = LocalHTTPServer(
             socketURL: socketURL,
+            authorizer: SocketAuthorizer(token: testCapabilityToken),
             toolHandler: { _, _ in
                 handlerStarted.fulfill()
                 do {
@@ -260,7 +264,7 @@ final class LocalHTTPServerCancellationTests: XCTestCase {
         defer { Darwin.close(client) }
         try writeAll(
             Data(
-                "POST /tools/source_status HTTP/1.1\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n{}".utf8
+                "POST /tools/source_status HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Bearer \(testCapabilityToken)\r\nContent-Length: 2\r\n\r\n{}".utf8
             ),
             to: client
         )
@@ -331,6 +335,7 @@ final class LocalHTTPServerCancellationTests: XCTestCase {
         )
         let server = LocalHTTPServer(
             socketURL: socketURL,
+            authorizer: SocketAuthorizer(token: testCapabilityToken),
             toolHandler: { _, _ in
                 ToolResponse(ok: true, source: "hostile-provider", message: oversizedMessage)
             },
@@ -351,7 +356,7 @@ final class LocalHTTPServerCancellationTests: XCTestCase {
         defer { Darwin.close(client) }
         try writeAll(
             Data(
-                "POST /tools/source_status HTTP/1.1\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n{}".utf8
+                "POST /tools/source_status HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Bearer \(testCapabilityToken)\r\nContent-Length: 2\r\n\r\n{}".utf8
             ),
             to: client
         )

--- a/Tests/M3MCPAppTests/LocalHTTPServerStartLockTests.swift
+++ b/Tests/M3MCPAppTests/LocalHTTPServerStartLockTests.swift
@@ -303,6 +303,7 @@ final class LocalHTTPServerStartLockTests: XCTestCase {
     ) -> LocalHTTPServer {
         LocalHTTPServer(
             socketURL: socketURL,
+            authorizer: SocketAuthorizer(token: testCapabilityToken),
             configuration: configuration,
             socketProbeOperations: socketProbeOperations,
             toolHandler: { _, _ in

--- a/Tests/M3MCPAppTests/SocketAuthenticationTests.swift
+++ b/Tests/M3MCPAppTests/SocketAuthenticationTests.swift
@@ -1,0 +1,178 @@
+import Darwin
+import Foundation
+import M3MCPCore
+import XCTest
+@testable import M3MCPApp
+
+/// Drives a real listener over a real Unix socket, because the thing under test is the door and a
+/// door has to be tried from outside.
+final class SocketAuthenticationTests: XCTestCase {
+    private var directory: URL!
+    private var socketURL: URL!
+    private var server: LocalHTTPServer!
+    private var accessLog: AccessLog!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = try makeShortTemporaryDirectory(prefix: "m3auth")
+        socketURL = directory.appendingPathComponent("server.sock")
+        accessLog = AccessLog()
+
+        let log = accessLog!
+        let endpoint = socketURL!
+        server = LocalHTTPServer(
+            socketURL: endpoint,
+            authorizer: SocketAuthorizer(token: testCapabilityToken),
+            toolHandler: { tool, _ in
+                ToolResponse(ok: true, source: "test", message: "handled \(tool)")
+            },
+            statusHandler: { includeActivity in
+                StatusResponse(
+                    ok: true,
+                    version: "test",
+                    endpoint: endpoint.path,
+                    services: [],
+                    recentActivity: includeActivity
+                        ? [
+                            ActivityEntry(
+                                endpoint: "m3mcp://tools/mail_search",
+                                provider: "Mail",
+                                status: "ok",
+                                detail: "1 item(s)",
+                                durationMilliseconds: 1,
+                                toolName: "mail_search",
+                                inputJSON: "{\"query\":\"secret\"}",
+                                outputJSON: "{\"ok\":true}"
+                            )
+                        ]
+                        : []
+                )
+            },
+            auditHandler: { attempt in
+                log.append(attempt)
+            }
+        )
+        try server.start()
+    }
+
+    override func tearDownWithError() throws {
+        server?.stop()
+        server = nil
+        if let directory {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Token
+
+    func testToolCallWithoutTokenIsRefused() throws {
+        let reply = try exchangeOverSocket(
+            at: socketURL,
+            request: toolCallRequest(tool: "source_status", token: nil)
+        )
+        XCTAssertEqual(reply.statusLine, "HTTP/1.1 401 Unauthorized")
+        XCTAssertTrue(reply.body.contains("needs a capability token"), reply.body)
+        XCTAssertEqual(accessLog.refusals.map(\.path), ["/tools/source_status"])
+        XCTAssertEqual(accessLog.refusals.map(\.allowed), [false])
+    }
+
+    func testToolCallWithTheWrongTokenIsRefused() throws {
+        let reply = try exchangeOverSocket(
+            at: socketURL,
+            request: toolCallRequest(tool: "source_status", token: testCapabilityToken + "x")
+        )
+        XCTAssertEqual(reply.statusLine, "HTTP/1.1 401 Unauthorized")
+        XCTAssertTrue(reply.body.contains("not the one this M3MCP instance issued"), reply.body)
+    }
+
+    func testToolCallWithTheConfiguredTokenGoesThrough() throws {
+        let reply = try exchangeOverSocket(
+            at: socketURL,
+            request: toolCallRequest(tool: "source_status", token: testCapabilityToken)
+        )
+        XCTAssertEqual(reply.statusLine, "HTTP/1.1 200 OK")
+        XCTAssertTrue(reply.body.contains("handled source_status"), reply.body)
+        XCTAssertTrue(accessLog.refusals.isEmpty, "an accepted call was logged as a refusal")
+    }
+
+    /// The bridge decodes a tool reply as a `ToolResponse`. A refusal shaped as anything else
+    /// reaches the MCP client as "unreadable response" rather than as the reason.
+    func testARefusedToolCallDecodesAsAToolResponseInTheBridge() throws {
+        let reply = try exchangeOverSocket(
+            at: socketURL,
+            request: toolCallRequest(tool: "mail_search", token: nil)
+        )
+        let decoded = try M3JSON.makeDecoder().decode(ToolResponse.self, from: Data(reply.body.utf8))
+        XCTAssertFalse(decoded.ok)
+        XCTAssertEqual(decoded.source, "M3MCP Server")
+        XCTAssertTrue(decoded.message?.contains("capability token") == true, decoded.message ?? "")
+    }
+
+    // MARK: - Health and status
+
+    func testHealthAnswersWithoutATokenAndCarriesNoActivityLog() throws {
+        let reply = try exchangeOverSocket(
+            at: socketURL,
+            request: "GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        )
+        XCTAssertEqual(reply.statusLine, "HTTP/1.1 200 OK")
+
+        let status = try M3JSON.makeDecoder().decode(StatusResponse.self, from: Data(reply.body.utf8))
+        XCTAssertTrue(status.recentActivity.isEmpty, "the public probe leaked the activity log")
+        XCTAssertTrue(accessLog.refusals.isEmpty)
+    }
+
+    func testStatusNeedsTheTokenBecauseItCarriesTheActivityLog() throws {
+        let refused = try exchangeOverSocket(
+            at: socketURL,
+            request: "GET /status HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        )
+        XCTAssertEqual(refused.statusLine, "HTTP/1.1 401 Unauthorized")
+        XCTAssertFalse(refused.body.contains("secret"), "a refused /status still returned activity")
+
+        let allowed = try exchangeOverSocket(
+            at: socketURL,
+            request: "GET /status HTTP/1.1\r\nHost: localhost\r\n"
+                + "Authorization: Bearer \(testCapabilityToken)\r\nConnection: close\r\n\r\n"
+        )
+        XCTAssertEqual(allowed.statusLine, "HTTP/1.1 200 OK")
+        let status = try M3JSON.makeDecoder().decode(StatusResponse.self, from: Data(allowed.body.utf8))
+        XCTAssertEqual(status.recentActivity.count, 1)
+    }
+
+    // MARK: - Header handling
+
+    func testTheSchemeIsCaseInsensitiveAndOtherSchemesAreRefused() throws {
+        let lowercase = try exchangeOverSocket(
+            at: socketURL,
+            request: "GET /status HTTP/1.1\r\nHost: localhost\r\n"
+                + "authorization: bearer \(testCapabilityToken)\r\nConnection: close\r\n\r\n"
+        )
+        XCTAssertEqual(lowercase.statusLine, "HTTP/1.1 200 OK")
+
+        let basic = try exchangeOverSocket(
+            at: socketURL,
+            request: "GET /status HTTP/1.1\r\nHost: localhost\r\n"
+                + "Authorization: Basic \(testCapabilityToken)\r\nConnection: close\r\n\r\n"
+        )
+        XCTAssertEqual(basic.statusLine, "HTTP/1.1 401 Unauthorized")
+    }
+}
+
+private final class AccessLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [AccessAttempt] = []
+
+    var refusals: [AccessAttempt] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage.filter { !$0.allowed }
+    }
+
+    func append(_ attempt: AccessAttempt) {
+        lock.lock()
+        storage.append(attempt)
+        lock.unlock()
+    }
+}

--- a/Tests/M3MCPAppTests/SocketAvailabilityTests.swift
+++ b/Tests/M3MCPAppTests/SocketAvailabilityTests.swift
@@ -1,0 +1,232 @@
+import Darwin
+import Foundation
+import M3MCPCore
+import XCTest
+@testable import M3MCPApp
+
+/// Availability is part of the access control here, because authorization cannot happen before the
+/// request has been read whole: the token is a header. So a connection that says nothing must not be
+/// able to take the endpoint away from the client that holds the token.
+final class SocketAvailabilityTests: XCTestCase {
+    private var directory: URL!
+    private var socketURL: URL!
+    private var server: LocalHTTPServer!
+    private var idle: [Int32] = []
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = try makeShortTemporaryDirectory(prefix: "m3load")
+        socketURL = directory.appendingPathComponent("server.sock")
+    }
+
+    override func tearDownWithError() throws {
+        for descriptor in idle {
+            Darwin.close(descriptor)
+        }
+        idle = []
+        server?.stop()
+        server = nil
+        if let directory {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        try super.tearDownWithError()
+    }
+
+    private func startServer(
+        openConnections: Int = 4,
+        concurrentRequests: Int = 4,
+        requestReadDeadline: TimeInterval = 15,
+        toolHandler: @escaping LocalHTTPServer.ToolHandler = { tool, _ in
+            ToolResponse(ok: true, source: "test", message: "handled \(tool)")
+        }
+    ) throws {
+        var configuration = LocalHTTPServer.Configuration()
+        configuration.maximumOpenConnections = openConnections
+        configuration.maximumConcurrentConnections = concurrentRequests
+        configuration.requestReadDeadline = requestReadDeadline
+
+        let endpoint = socketURL!
+        let server = LocalHTTPServer(
+            socketURL: endpoint,
+            authorizer: SocketAuthorizer(token: testCapabilityToken),
+            configuration: configuration,
+            toolHandler: toolHandler,
+            statusHandler: { _ in
+                StatusResponse(
+                    ok: true,
+                    version: "test",
+                    endpoint: endpoint.path,
+                    services: [],
+                    recentActivity: []
+                )
+            }
+        )
+        try server.start()
+        self.server = server
+    }
+
+    /// Opens connections that say nothing at all, the cheapest local attack there is.
+    @discardableResult
+    private func openSilentConnections(_ count: Int) -> Int {
+        for _ in 0..<count {
+            if let descriptor = connectToSocketWithRetry(at: socketURL) {
+                idle.append(descriptor)
+            }
+        }
+        // The accept loop admits from its own queue; give it a moment to take them all in.
+        Thread.sleep(forTimeInterval: 0.15)
+        return idle.count
+    }
+
+    // MARK: - Silence must not buy an outage
+
+    func testSilentConnectionsAtTheCapDoNotTakeTheEndpointAway() throws {
+        try startServer(openConnections: 4)
+        XCTAssertEqual(openSilentConnections(4), 4)
+
+        let health = try exchangeOverSocket(
+            at: socketURL,
+            request: "GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        )
+        XCTAssertEqual(health.statusLine, "HTTP/1.1 200 OK")
+
+        let call = try exchangeOverSocket(
+            at: socketURL,
+            request: toolCallRequest(tool: "source_status", token: testCapabilityToken)
+        )
+        XCTAssertEqual(call.statusLine, "HTTP/1.1 200 OK")
+        XCTAssertTrue(call.body.contains("handled source_status"), call.body)
+    }
+
+    /// Far past the cap, and repeatedly: the point is that filling every slot buys a burst and not
+    /// an outage, because each new arrival costs the flooder its oldest slot.
+    func testManyMoreSilentConnectionsThanSlotsStillYieldTheEndpoint() throws {
+        try startServer(openConnections: 16)
+        XCTAssertGreaterThanOrEqual(openSilentConnections(160), 16)
+
+        for attempt in 1...5 {
+            let call = try exchangeOverSocket(
+                at: socketURL,
+                request: toolCallRequest(tool: "source_status", token: testCapabilityToken)
+            )
+            XCTAssertEqual(call.statusLine, "HTTP/1.1 200 OK", "attempt \(attempt)")
+        }
+    }
+
+    /// The displaced connection is told why, rather than being closed without a word.
+    func testTheDisplacedConnectionIsToldWhy() throws {
+        try startServer(openConnections: 1)
+        let victim = try connectToSocket(at: socketURL)
+        defer { Darwin.close(victim) }
+        Thread.sleep(forTimeInterval: 0.15)
+
+        let call = try exchangeOverSocket(
+            at: socketURL,
+            request: toolCallRequest(tool: "source_status", token: testCapabilityToken)
+        )
+        XCTAssertEqual(call.statusLine, "HTTP/1.1 200 OK")
+
+        let displaced = try readUntilSocketClose(from: victim, timeout: 2)
+        let text = String(decoding: displaced, as: UTF8.self)
+        XCTAssertTrue(text.hasPrefix("HTTP/1.1 503 Service Unavailable\r\n"), text)
+        XCTAssertTrue(text.contains("Displaced by a newer connection"), text)
+    }
+
+    // MARK: - A half-read request is work in progress
+
+    /// A connection that has sent something is not silent, so it is not displaced. When every slot
+    /// holds one of those, the refusal is the honest answer.
+    func testAConnectionThatHasSentSomethingIsNotDisplacedAndTheCapThenHolds() throws {
+        try startServer(openConnections: 2)
+
+        var partial: [Int32] = []
+        for _ in 0..<2 {
+            let descriptor = try connectToSocket(at: socketURL)
+            partial.append(descriptor)
+            idle.append(descriptor)
+            try writeAllToSocket(Data("GET /heal".utf8), to: descriptor)
+        }
+        Thread.sleep(forTimeInterval: 0.2)
+
+        let refused = try exchangeOverSocket(
+            at: socketURL,
+            request: toolCallRequest(tool: "source_status", token: testCapabilityToken),
+            timeout: 3
+        )
+        XCTAssertEqual(refused.statusLine, "HTTP/1.1 503 Service Unavailable")
+        XCTAssertTrue(refused.body.contains("connection limit"), refused.body)
+
+        // The half-read requests survived and still complete.
+        for descriptor in partial {
+            try writeAllToSocket(Data("th HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n".utf8), to: descriptor)
+        }
+        for descriptor in partial {
+            let reply = try readUntilSocketClose(from: descriptor, timeout: 3)
+            XCTAssertTrue(
+                String(decoding: reply, as: UTF8.self).hasPrefix("HTTP/1.1 200 OK\r\n"),
+                "a half-read request was thrown away instead of finished"
+            )
+        }
+    }
+
+    // MARK: - Deadlines
+
+    func testAnUnfinishedRequestIsDroppedWhenTheDeadlinePassesAndTheSlotComesBack() throws {
+        try startServer(openConnections: 1, requestReadDeadline: 0.3)
+
+        let stalled = try connectToSocket(at: socketURL)
+        defer { Darwin.close(stalled) }
+        try writeAllToSocket(Data("GET /heal".utf8), to: stalled)
+
+        let reply = try readUntilSocketClose(from: stalled, timeout: 3)
+        let text = String(decoding: reply, as: UTF8.self)
+        XCTAssertTrue(text.hasPrefix("HTTP/1.1 408 Request Timeout\r\n"), text)
+
+        // The one slot is back, so the endpoint works again without anything else being closed.
+        let health = try exchangeOverSocket(
+            at: socketURL,
+            request: "GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        )
+        XCTAssertEqual(health.statusLine, "HTTP/1.1 200 OK")
+    }
+
+    // MARK: - The in-flight cap is a separate, honest limit
+
+    /// Silence is cheap and a thread is the price of having said something. When every serving slot
+    /// is busy the answer is 503, and it arrives at once rather than after a wait.
+    func testARequestBeyondTheInFlightCapIsRefusedPromptly() throws {
+        let started = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+        try startServer(openConnections: 8, concurrentRequests: 1, toolHandler: { tool, _ in
+            started.signal()
+            await withCheckedContinuation { continuation in
+                DispatchQueue.global().async {
+                    release.wait()
+                    continuation.resume()
+                }
+            }
+            return ToolResponse(ok: true, source: "test", message: "handled \(tool)")
+        })
+
+        let slow = try connectToSocket(at: socketURL)
+        defer { Darwin.close(slow) }
+        try writeAllToSocket(
+            Data(toolCallRequest(tool: "source_status", token: testCapabilityToken).utf8),
+            to: slow
+        )
+        XCTAssertEqual(started.wait(timeout: .now() + 3), .success)
+
+        let began = Date()
+        let refused = try exchangeOverSocket(
+            at: socketURL,
+            request: toolCallRequest(tool: "source_status", token: testCapabilityToken),
+            timeout: 3
+        )
+        XCTAssertEqual(refused.statusLine, "HTTP/1.1 503 Service Unavailable")
+        XCTAssertLessThan(Date().timeIntervalSince(began), 2, "the refusal waited for the busy slot")
+
+        release.signal()
+        let finished = try readUntilSocketClose(from: slow, timeout: 5)
+        XCTAssertTrue(String(decoding: finished, as: UTF8.self).hasPrefix("HTTP/1.1 200 OK\r\n"))
+    }
+}

--- a/Tests/M3MCPAppTests/SocketAvailabilityTests.swift
+++ b/Tests/M3MCPAppTests/SocketAvailabilityTests.swift
@@ -190,6 +190,22 @@ final class SocketAvailabilityTests: XCTestCase {
         XCTAssertEqual(health.statusLine, "HTTP/1.1 200 OK")
     }
 
+    /// A client that shuts down its write side after half a request still gets told why, the way it
+    /// did when the request was read by a parked thread.
+    func testAHalfOpenClientIsToldItsRequestWasIncomplete() throws {
+        try startServer(openConnections: 2)
+
+        let client = try connectToSocket(at: socketURL)
+        defer { Darwin.close(client) }
+        try writeAllToSocket(Data("GET /heal".utf8), to: client)
+        XCTAssertEqual(Darwin.shutdown(client, SHUT_WR), 0)
+
+        let reply = try readUntilSocketClose(from: client, timeout: 3)
+        let text = String(decoding: reply, as: UTF8.self)
+        XCTAssertTrue(text.hasPrefix("HTTP/1.1 400 Bad Request\r\n"), text)
+        XCTAssertTrue(text.contains("Could not read a complete request"), text)
+    }
+
     // MARK: - The in-flight cap is a separate, honest limit
 
     /// Silence is cheap and a thread is the price of having said something. When every serving slot

--- a/Tests/M3MCPAppTests/SocketPeerPinTests.swift
+++ b/Tests/M3MCPAppTests/SocketPeerPinTests.swift
@@ -1,0 +1,197 @@
+import Darwin
+import Foundation
+import M3MCPCore
+import XCTest
+@testable import M3MCPApp
+
+/// The pin, tried from outside with two different binaries: this test runner, and `/usr/bin/curl`.
+/// A copied token has to stop working when it is presented by the wrong one.
+final class SocketPeerPinTests: XCTestCase {
+    private var directory: URL!
+    private var socketURL: URL!
+    private var server: LocalHTTPServer!
+    private var peers: PeerLog!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = try makeShortTemporaryDirectory(prefix: "m3pin")
+        socketURL = directory.appendingPathComponent("server.sock")
+        peers = PeerLog()
+    }
+
+    override func tearDownWithError() throws {
+        server?.stop()
+        server = nil
+        if let directory {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        try super.tearDownWithError()
+    }
+
+    private func startServer(pinnedTo hashes: Set<String>) throws {
+        let log = peers!
+        let endpoint = socketURL!
+        let server = LocalHTTPServer(
+            socketURL: endpoint,
+            authorizer: SocketAuthorizer(
+                token: testCapabilityToken,
+                trustedCodeDirectoryHashes: hashes,
+                trustDescription: "pinned to the test fixture"
+            ),
+            toolHandler: { tool, _ in
+                ToolResponse(ok: true, source: "test", message: "handled \(tool)")
+            },
+            statusHandler: { _ in
+                StatusResponse(
+                    ok: true,
+                    version: "test",
+                    endpoint: endpoint.path,
+                    services: [],
+                    recentActivity: []
+                )
+            },
+            auditHandler: { attempt in
+                log.append(attempt)
+            }
+        )
+        try server.start()
+        self.server = server
+    }
+
+    private func ownCodeDirectoryHash() throws -> String {
+        guard let hash = PeerIdentity.codeDirectoryHashOfCurrentProcess() else {
+            throw XCTSkip("this test runner has no readable code signature, so nothing can be pinned to it")
+        }
+        return hash
+    }
+
+    // MARK: - The pinned binary
+
+    func testThePinnedBinaryWithTheTokenGoesThrough() throws {
+        try startServer(pinnedTo: [try ownCodeDirectoryHash()])
+
+        let reply = try exchangeOverSocket(
+            at: socketURL,
+            request: toolCallRequest(tool: "source_status", token: testCapabilityToken)
+        )
+        XCTAssertEqual(reply.statusLine, "HTTP/1.1 200 OK")
+        XCTAssertTrue(reply.body.contains("handled source_status"), reply.body)
+    }
+
+    /// The token is right and the binary is not. This is the case a token on its own cannot cover.
+    func testTheSameTokenFromAnUnpinnedBinaryIsRefused() throws {
+        try startServer(pinnedTo: ["0000000000000000000000000000000000000000"])
+
+        let reply = try exchangeOverSocket(
+            at: socketURL,
+            request: toolCallRequest(tool: "source_status", token: testCapabilityToken)
+        )
+        XCTAssertEqual(reply.statusLine, "HTTP/1.1 403 Forbidden")
+        XCTAssertTrue(reply.body.contains("not configured for"), reply.body)
+
+        let refusals = peers.refusals
+        XCTAssertEqual(refusals.count, 1)
+        XCTAssertEqual(refusals.first?.peer.processIdentifier, getpid())
+        XCTAssertEqual(refusals.first?.peer.userIdentifier, getuid())
+        XCTAssertEqual(refusals.first?.peer.codeDirectoryHash, try ownCodeDirectoryHash())
+        XCTAssertTrue(refusals.first?.peer.signatureValid == true)
+    }
+
+    // MARK: - A genuinely foreign binary
+
+    /// `/usr/bin/curl` is a different executable with a different code directory hash, and it is the
+    /// probe the README documents. Pinned to this test runner, it must be refused even with the
+    /// correct token, and must still be able to read `/health`.
+    func testAForeignBinaryIsRefusedWithTheTokenAndStillReadsHealth() throws {
+        let curl = URL(fileURLWithPath: "/usr/bin/curl")
+        guard FileManager.default.isExecutableFile(atPath: curl.path) else {
+            throw XCTSkip("no /usr/bin/curl on this machine")
+        }
+        try startServer(pinnedTo: [try ownCodeDirectoryHash()])
+
+        let toolCall = try runCurl(
+            arguments: [
+                "--silent", "--show-error",
+                "--unix-socket", socketURL.path,
+                "--output", "/dev/null",
+                "--write-out", "%{http_code}",
+                "--header", "Content-Type: application/json",
+                "--header", "Authorization: Bearer \(testCapabilityToken)",
+                "--data", "{}",
+                "http://localhost/tools/source_status"
+            ]
+        )
+        XCTAssertEqual(toolCall, "403", "a foreign binary got in on a copied token")
+
+        let health = try runCurl(
+            arguments: [
+                "--silent", "--show-error",
+                "--unix-socket", socketURL.path,
+                "--output", "/dev/null",
+                "--write-out", "%{http_code}",
+                "http://localhost/health"
+            ]
+        )
+        XCTAssertEqual(health, "200", "the documented probe stopped working for other binaries")
+
+        let refusals = peers.refusals
+        XCTAssertEqual(refusals.count, 1)
+        XCTAssertNotEqual(refusals.first?.peer.processIdentifier, getpid())
+        XCTAssertEqual(refusals.first?.peer.executablePath, curl.path)
+        XCTAssertNotEqual(refusals.first?.peer.codeDirectoryHash, try ownCodeDirectoryHash())
+    }
+
+    /// Without a pin the same foreign binary is accepted on the token alone. This is the fallback an
+    /// installation without a sibling bridge falls into, and it has to be visible rather than assumed.
+    func testWithoutAPinTheForeignBinaryIsAcceptedOnTheTokenAlone() throws {
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/curl") else {
+            throw XCTSkip("no /usr/bin/curl on this machine")
+        }
+        try startServer(pinnedTo: [])
+
+        let toolCall = try runCurl(
+            arguments: [
+                "--silent", "--show-error",
+                "--unix-socket", socketURL.path,
+                "--output", "/dev/null",
+                "--write-out", "%{http_code}",
+                "--header", "Content-Type: application/json",
+                "--header", "Authorization: Bearer \(testCapabilityToken)",
+                "--data", "{}",
+                "http://localhost/tools/source_status"
+            ]
+        )
+        XCTAssertEqual(toolCall, "200")
+        XCTAssertTrue(peers.refusals.isEmpty)
+    }
+
+    private func runCurl(arguments: [String]) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/curl")
+        process.arguments = arguments
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = Pipe()
+        try process.run()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return String(decoding: data, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private final class PeerLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [AccessAttempt] = []
+
+    var refusals: [AccessAttempt] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage.filter { !$0.allowed }
+    }
+
+    func append(_ attempt: AccessAttempt) {
+        lock.lock()
+        storage.append(attempt)
+        lock.unlock()
+    }
+}

--- a/Tests/M3MCPAppTests/SocketTestSupport.swift
+++ b/Tests/M3MCPAppTests/SocketTestSupport.swift
@@ -47,6 +47,19 @@ func connectToSocket(at url: URL) throws -> Int32 {
     return descriptor
 }
 
+/// The listen backlog is matched to the connection cap, so a burst larger than the cap can be met
+/// with ECONNREFUSED while the accept loop is still draining. That is the kernel, not the server,
+/// and a client retries. Returns nil when the endpoint refused for the whole window.
+func connectToSocketWithRetry(at url: URL, attempts: Int = 80) -> Int32? {
+    for attempt in 0..<attempts {
+        if let descriptor = try? connectToSocket(at: url) {
+            return descriptor
+        }
+        Thread.sleep(forTimeInterval: 0.002 * Double(attempt + 1))
+    }
+    return nil
+}
+
 func writeAllToSocket(_ data: Data, to descriptor: Int32) throws {
     try data.withUnsafeBytes { raw in
         guard let base = raw.baseAddress else { return }
@@ -94,7 +107,9 @@ func exchangeOverSocket(
     request: String,
     timeout: TimeInterval = 5
 ) throws -> (statusLine: String, body: String) {
-    let descriptor = try connectToSocket(at: url)
+    guard let descriptor = connectToSocketWithRetry(at: url) else {
+        throw POSIXError(.ECONNREFUSED)
+    }
     defer { Darwin.close(descriptor) }
     try writeAllToSocket(Data(request.utf8), to: descriptor)
     let raw = try readUntilSocketClose(from: descriptor, timeout: timeout)

--- a/Tests/M3MCPAppTests/SocketTestSupport.swift
+++ b/Tests/M3MCPAppTests/SocketTestSupport.swift
@@ -1,0 +1,117 @@
+import Darwin
+import Foundation
+import XCTest
+
+/// The token the server-level tests build their authorizer with.
+///
+/// A fixed literal rather than a generated one: these tests are about the door, not about the key,
+/// and a constant keeps the raw HTTP in the assertions readable.
+let testCapabilityToken = "test-capability-token"
+
+/// `sockaddr_un.sun_path` is 104 bytes. Foundation's `temporaryDirectory` on macOS is a per-user
+/// path long enough to overflow it, so socket tests use the short real temp root instead.
+func makeShortTemporaryDirectory(prefix: String) throws -> URL {
+    let directory = URL(
+        fileURLWithPath: "/private/tmp/\(prefix)-\(UUID().uuidString.prefix(8))",
+        isDirectory: true
+    )
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+    return directory
+}
+
+func connectToSocket(at url: URL) throws -> Int32 {
+    let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard descriptor >= 0 else {
+        throw POSIXError(.init(rawValue: errno) ?? .EIO)
+    }
+
+    var address = sockaddr_un()
+    address.sun_family = sa_family_t(AF_UNIX)
+    let capacity = MemoryLayout.size(ofValue: address.sun_path)
+    withUnsafeMutablePointer(to: &address.sun_path) { pointer in
+        pointer.withMemoryRebound(to: CChar.self, capacity: capacity) { destination in
+            _ = strlcpy(destination, url.path, capacity)
+        }
+    }
+
+    let result = withUnsafePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { addressPointer in
+            Darwin.connect(descriptor, addressPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    guard result == 0 else {
+        let code = errno
+        Darwin.close(descriptor)
+        throw POSIXError(.init(rawValue: code) ?? .EIO)
+    }
+    return descriptor
+}
+
+func writeAllToSocket(_ data: Data, to descriptor: Int32) throws {
+    try data.withUnsafeBytes { raw in
+        guard let base = raw.baseAddress else { return }
+        var offset = 0
+        while offset < raw.count {
+            let count = Darwin.write(descriptor, base.advanced(by: offset), raw.count - offset)
+            if count < 0, errno == EINTR { continue }
+            guard count > 0 else {
+                throw POSIXError(.init(rawValue: errno) ?? .EIO)
+            }
+            offset += count
+        }
+    }
+}
+
+func readUntilSocketClose(from descriptor: Int32, timeout: TimeInterval) throws -> Data {
+    var result = Data()
+    var bytes = [UInt8](repeating: 0, count: 4_096)
+    let deadline = Date().addingTimeInterval(timeout)
+    while true {
+        let remaining = deadline.timeIntervalSinceNow
+        guard remaining > 0 else { throw POSIXError(.ETIMEDOUT) }
+
+        var readiness = pollfd(fd: descriptor, events: Int16(POLLIN | POLLHUP), revents: 0)
+        let ready = Darwin.poll(&readiness, 1, Int32(remaining * 1_000))
+        if ready < 0, errno == EINTR { continue }
+        guard ready > 0 else {
+            throw POSIXError(ready == 0 ? .ETIMEDOUT : (.init(rawValue: errno) ?? .EIO))
+        }
+
+        let count = bytes.withUnsafeMutableBytes { raw in
+            Darwin.read(descriptor, raw.baseAddress, raw.count)
+        }
+        if count == 0 { return result }
+        if count < 0, errno == EINTR { continue }
+        if count < 0 { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+        result.append(contentsOf: bytes[0..<count])
+    }
+}
+
+/// One request, one reply, one connection. The endpoint answers with `Connection: close`, so a
+/// read to EOF is the whole response.
+func exchangeOverSocket(
+    at url: URL,
+    request: String,
+    timeout: TimeInterval = 5
+) throws -> (statusLine: String, body: String) {
+    let descriptor = try connectToSocket(at: url)
+    defer { Darwin.close(descriptor) }
+    try writeAllToSocket(Data(request.utf8), to: descriptor)
+    let raw = try readUntilSocketClose(from: descriptor, timeout: timeout)
+    let text = String(decoding: raw, as: UTF8.self)
+    let statusLine = text.components(separatedBy: "\r\n").first ?? ""
+    let body = text.components(separatedBy: "\r\n\r\n").dropFirst().joined(separator: "\r\n\r\n")
+    return (statusLine, body)
+}
+
+func toolCallRequest(tool: String, token: String?) -> String {
+    var request = "POST /tools/\(tool) HTTP/1.1\r\n"
+    request += "Host: localhost\r\n"
+    request += "Content-Type: application/json\r\n"
+    if let token {
+        request += "Authorization: Bearer \(token)\r\n"
+    }
+    request += "Content-Length: 2\r\n"
+    request += "Connection: close\r\n\r\n{}"
+    return request
+}

--- a/Tests/M3MCPBridgeTests/MCPServerFormattingTests.swift
+++ b/Tests/M3MCPBridgeTests/MCPServerFormattingTests.swift
@@ -381,7 +381,7 @@ final class MCPServerFormattingTests: XCTestCase {
     func testCancellingLocalAppClientInterruptsHeldUnixSocketRead() async throws {
         let fixture = try HeldUnixSocketFixture()
         defer { fixture.close() }
-        let client = LocalAppClient(socketURL: fixture.socketURL, timeout: 30)
+        let client = LocalAppClient(socketURL: fixture.socketURL, timeout: 30, capabilityToken: "fixture-token")
 
         let call = Task {
             await client.call(tool: "source_status", arguments: [:])
@@ -402,6 +402,7 @@ final class MCPServerFormattingTests: XCTestCase {
         let client = LocalAppClient(
             socketURL: fixture.socketURL,
             timeout: 2,
+            capabilityToken: "fixture-token",
             registeredSocketHook: { controller in
                 // This is the exact old race: shutdown runs while the descriptor is registered but
                 // not connected, so Darwin can return ENOTCONN. The post-connect locked recheck must
@@ -457,7 +458,7 @@ final class MCPServerFormattingTests: XCTestCase {
     func testLocalAppClientTimesOutWhenUnixSocketHoldsResponseOpen() async throws {
         let fixture = try HeldUnixSocketFixture()
         defer { fixture.close() }
-        let client = LocalAppClient(socketURL: fixture.socketURL, timeout: 1)
+        let client = LocalAppClient(socketURL: fixture.socketURL, timeout: 1, capabilityToken: "fixture-token")
 
         let started = Date()
         let response = await client.call(tool: "source_status", arguments: [:])
@@ -477,7 +478,7 @@ final class MCPServerFormattingTests: XCTestCase {
             interByteDelayMicroseconds: 50_000
         )
         defer { fixture.close() }
-        let client = LocalAppClient(socketURL: fixture.socketURL, timeout: 0.25)
+        let client = LocalAppClient(socketURL: fixture.socketURL, timeout: 0.25, capabilityToken: "fixture-token")
 
         let started = Date()
         let response = await client.call(tool: "source_status", arguments: [:])
@@ -496,7 +497,7 @@ final class MCPServerFormattingTests: XCTestCase {
         )
         let fixture = try ScriptedUnixSocketFixture(response: wire)
         defer { fixture.close() }
-        let client = LocalAppClient(socketURL: fixture.socketURL, timeout: 10)
+        let client = LocalAppClient(socketURL: fixture.socketURL, timeout: 10, capabilityToken: "fixture-token")
 
         let started = Date()
         let response = await client.call(tool: "source_status", arguments: [:])
@@ -514,7 +515,7 @@ final class MCPServerFormattingTests: XCTestCase {
         wire.append(body)
         let fixture = try ScriptedUnixSocketFixture(response: wire)
         defer { fixture.close() }
-        let client = LocalAppClient(socketURL: fixture.socketURL, timeout: 10)
+        let client = LocalAppClient(socketURL: fixture.socketURL, timeout: 10, capabilityToken: "fixture-token")
 
         let started = Date()
         let response = await client.call(tool: "source_status", arguments: [:])

--- a/Tests/M3MCPCoreTests/CapabilityTokenTests.swift
+++ b/Tests/M3MCPCoreTests/CapabilityTokenTests.swift
@@ -49,11 +49,21 @@ final class CapabilityTokenTests: XCTestCase {
         XCTAssertFalse(SocketAuthorizer.isPublic(method: "GET", path: "/health/../status"))
     }
 
+    /// A server without a pin never looks at the peer, so any identity does here.
+    private var unpinnedPeer: PeerIdentity {
+        PeerIdentity(processIdentifier: 1, userIdentifier: 501)
+    }
+
     func testTheAuthorizerRefusesAMissingAndAWrongToken() {
         let authorizer = SocketAuthorizer(token: "expected")
 
         XCTAssertEqual(
-            authorizer.authorize(method: "POST", path: "/tools/mail_search", authorizationHeader: nil),
+            authorizer.authorize(
+                method: "POST",
+                path: "/tools/mail_search",
+                authorizationHeader: nil,
+                peer: unpinnedPeer
+            ),
             .deny(
                 status: 401,
                 reason: "This endpoint needs a capability token. Send 'Authorization: Bearer <token>'. "
@@ -65,7 +75,8 @@ final class CapabilityTokenTests: XCTestCase {
             authorizer.authorize(
                 method: "POST",
                 path: "/tools/mail_search",
-                authorizationHeader: "Bearer wrong"
+                authorizationHeader: "Bearer wrong",
+                peer: unpinnedPeer
             ),
             .deny(status: 401, reason: "The capability token is not the one this M3MCP instance issued.")
         )
@@ -73,12 +84,18 @@ final class CapabilityTokenTests: XCTestCase {
             authorizer.authorize(
                 method: "POST",
                 path: "/tools/mail_search",
-                authorizationHeader: "Bearer expected"
+                authorizationHeader: "Bearer expected",
+                peer: unpinnedPeer
             ),
             .allow
         )
         XCTAssertEqual(
-            authorizer.authorize(method: "GET", path: "/health", authorizationHeader: nil),
+            authorizer.authorize(
+                method: "GET",
+                path: "/health",
+                authorizationHeader: nil,
+                peer: unpinnedPeer
+            ),
             .allow
         )
     }

--- a/Tests/M3MCPCoreTests/CapabilityTokenTests.swift
+++ b/Tests/M3MCPCoreTests/CapabilityTokenTests.swift
@@ -170,7 +170,10 @@ final class CapabilityTokenTests: XCTestCase {
         case .resolved(let resolution):
             XCTFail("a client invented the token \(resolution.origin)")
         case .missing(let reason):
-            XCTAssertTrue(reason.contains(service), reason)
+            // The property under test is that nothing was invented. The wording depends on why the
+            // keychain said no, and a locked or absent login keychain on a build machine answers
+            // with an OSStatus message instead of naming the item.
+            XCTAssertFalse(reason.isEmpty, "a refusal has to say something")
         }
     }
 }

--- a/Tests/M3MCPCoreTests/CapabilityTokenTests.swift
+++ b/Tests/M3MCPCoreTests/CapabilityTokenTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Security
+import XCTest
+@testable import M3MCPCore
+
+final class CapabilityTokenTests: XCTestCase {
+    // MARK: - Primitives
+
+    func testGeneratedTokensAreDistinctAndSurviveAConfigFile() throws {
+        var seen = Set<String>()
+        for _ in 0..<64 {
+            let token = try CapabilityToken.generate()
+            XCTAssertEqual(token.count, 43, "32 random bytes in unpadded base64url are 43 characters")
+            XCTAssertTrue(
+                token.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" },
+                "a token must survive an environment variable, a JSON string and an HTTP header: \(token)"
+            )
+            XCTAssertTrue(seen.insert(token).inserted, "SecRandomCopyBytes repeated a token")
+        }
+    }
+
+    func testComparisonRejectsPrefixesLengthMismatchesAndEmptyExpectations() {
+        XCTAssertTrue(CapabilityToken.matches("abc", "abc"))
+        XCTAssertFalse(CapabilityToken.matches("ab", "abc"))
+        XCTAssertFalse(CapabilityToken.matches("abcd", "abc"))
+        XCTAssertFalse(CapabilityToken.matches("abd", "abc"))
+        // An unconfigured server must not accept the empty string as its own token.
+        XCTAssertFalse(CapabilityToken.matches("", ""))
+        XCTAssertFalse(CapabilityToken.matches("anything", ""))
+    }
+
+    func testBearerParsingIgnoresSchemeCaseAndRejectsEverythingElse() {
+        XCTAssertEqual(SocketAuthorizer.bearerToken(in: "Bearer abc"), "abc")
+        XCTAssertEqual(SocketAuthorizer.bearerToken(in: "bearer abc"), "abc")
+        XCTAssertEqual(SocketAuthorizer.bearerToken(in: "  BEARER   abc  "), "abc")
+        XCTAssertNil(SocketAuthorizer.bearerToken(in: "Basic abc"))
+        XCTAssertNil(SocketAuthorizer.bearerToken(in: "abc"))
+        XCTAssertNil(SocketAuthorizer.bearerToken(in: "Bearer"))
+        XCTAssertNil(SocketAuthorizer.bearerToken(in: "Bearer  "))
+        XCTAssertNil(SocketAuthorizer.bearerToken(in: nil))
+    }
+
+    // MARK: - Decisions
+
+    func testHealthIsTheOnlyPathThatAnswersWithoutAToken() {
+        XCTAssertTrue(SocketAuthorizer.isPublic(method: "GET", path: "/health"))
+        XCTAssertFalse(SocketAuthorizer.isPublic(method: "GET", path: "/status"))
+        XCTAssertFalse(SocketAuthorizer.isPublic(method: "POST", path: "/health"))
+        XCTAssertFalse(SocketAuthorizer.isPublic(method: "GET", path: "/health/../status"))
+    }
+
+    func testTheAuthorizerRefusesAMissingAndAWrongToken() {
+        let authorizer = SocketAuthorizer(token: "expected")
+
+        XCTAssertEqual(
+            authorizer.authorize(method: "POST", path: "/tools/mail_search", authorizationHeader: nil),
+            .deny(
+                status: 401,
+                reason: "This endpoint needs a capability token. Send 'Authorization: Bearer <token>'. "
+                    + "M3MCPBridge reads the token from M3MCP_TOKEN or from the login keychain; "
+                    + "the M3MCP app shows it under Server."
+            )
+        )
+        XCTAssertEqual(
+            authorizer.authorize(
+                method: "POST",
+                path: "/tools/mail_search",
+                authorizationHeader: "Bearer wrong"
+            ),
+            .deny(status: 401, reason: "The capability token is not the one this M3MCP instance issued.")
+        )
+        XCTAssertEqual(
+            authorizer.authorize(
+                method: "POST",
+                path: "/tools/mail_search",
+                authorizationHeader: "Bearer expected"
+            ),
+            .allow
+        )
+        XCTAssertEqual(
+            authorizer.authorize(method: "GET", path: "/health", authorizationHeader: nil),
+            .allow
+        )
+    }
+
+    // MARK: - Resolution
+
+    func testTheEnvironmentOverrideWinsOverTheKeychain() throws {
+        // Reading a variable this process does not set proves the fall-through, not the override, so
+        // exercise the override through the documented variable itself.
+        guard ProcessInfo.processInfo.environment[CapabilityToken.environmentKey] == nil else {
+            throw XCTSkip("\(CapabilityToken.environmentKey) is already set in this environment")
+        }
+        setenv(CapabilityToken.environmentKey, "from-environment", 1)
+        defer { unsetenv(CapabilityToken.environmentKey) }
+
+        let resolved = try CapabilityToken.loadOrCreate(service: "de.markzimmermann.m3mcp.test.never-used")
+        XCTAssertEqual(resolved.token, "from-environment")
+        XCTAssertTrue(resolved.origin.contains(CapabilityToken.environmentKey))
+
+        switch CapabilityToken.forClient(service: "de.markzimmermann.m3mcp.test.never-used") {
+        case .resolved(let client):
+            XCTAssertEqual(client.token, "from-environment")
+        case .missing(let reason):
+            XCTFail("the environment override was not seen by a client: \(reason)")
+        }
+    }
+
+    /// The keychain is the part that cannot be faked, so it is exercised for real and skipped rather
+    /// than failed where the login keychain is unavailable, as it can be on a CI runner.
+    func testAnItemThisBinaryWroteIsReadableAgainWithoutInteraction() throws {
+        let service = "de.markzimmermann.m3mcp.test.\(UUID().uuidString)"
+        let token = try CapabilityToken.generate()
+
+        do {
+            try CapabilityToken.write(token: token, service: service, account: CapabilityToken.defaultAccount)
+        } catch {
+            throw XCTSkip("no writable login keychain in this environment: \(error.localizedDescription)")
+        }
+        defer { try? CapabilityToken.delete(service: service, account: CapabilityToken.defaultAccount) }
+
+        XCTAssertEqual(
+            try CapabilityToken.read(service: service, account: CapabilityToken.defaultAccount),
+            token
+        )
+
+        // The bridge's path: no interaction allowed. The item was created by this same binary, so it
+        // is on its own ACL and must come back without a panel.
+        let started = Date()
+        let withoutInteraction = try CapabilityToken.read(
+            service: service,
+            account: CapabilityToken.defaultAccount,
+            allowingInteraction: false
+        )
+        XCTAssertEqual(withoutInteraction, token)
+        XCTAssertLessThan(
+            Date().timeIntervalSince(started),
+            5,
+            "a non-interactive keychain read must be bounded, not a hang"
+        )
+
+        try CapabilityToken.delete(service: service, account: CapabilityToken.defaultAccount)
+        XCTAssertNil(try CapabilityToken.read(service: service, account: CapabilityToken.defaultAccount))
+    }
+
+    func testAClientReportsAMissingItemRatherThanInventingAToken() throws {
+        guard ProcessInfo.processInfo.environment[CapabilityToken.environmentKey] == nil else {
+            throw XCTSkip("\(CapabilityToken.environmentKey) is set, so the keychain path is not reached")
+        }
+
+        let service = "de.markzimmermann.m3mcp.test.\(UUID().uuidString)"
+        switch CapabilityToken.forClient(service: service) {
+        case .resolved(let resolution):
+            XCTFail("a client invented the token \(resolution.origin)")
+        case .missing(let reason):
+            XCTAssertTrue(reason.contains(service), reason)
+        }
+    }
+}

--- a/Tests/M3MCPCoreTests/PeerIdentityPinTests.swift
+++ b/Tests/M3MCPCoreTests/PeerIdentityPinTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+import XCTest
+@testable import M3MCPCore
+
+final class PeerIdentityPinTests: XCTestCase {
+    private let bundledBridge = "1111111111111111111111111111111111111111"
+
+    private func pinnedAuthorizer() -> SocketAuthorizer {
+        SocketAuthorizer(
+            token: "expected",
+            trustedCodeDirectoryHashes: [bundledBridge],
+            trustDescription: "pinned to /Applications/M3MCP.app/Contents/MacOS/M3MCPBridge"
+        )
+    }
+
+    private func peer(hash: String?, valid: Bool = true) -> PeerIdentity {
+        PeerIdentity(
+            processIdentifier: 4_242,
+            userIdentifier: 501,
+            signingIdentifier: "SomeClient",
+            codeDirectoryHash: hash,
+            executablePath: "/tmp/someclient",
+            signatureValid: valid
+        )
+    }
+
+    func testAValidTokenFromThePinnedBinaryGoesThrough() {
+        XCTAssertEqual(
+            pinnedAuthorizer().authorize(
+                method: "POST",
+                path: "/tools/mail_search",
+                authorizationHeader: "Bearer expected",
+                peer: peer(hash: bundledBridge)
+            ),
+            .allow
+        )
+    }
+
+    /// The pin is stored and compared lowercased, because `codesign` prints one case and callers of
+    /// `M3MCP_TRUSTED_CLIENT_CDHASH` will eventually paste the other.
+    func testHashComparisonIgnoresCase() {
+        let authorizer = SocketAuthorizer(
+            token: "expected",
+            trustedCodeDirectoryHashes: ["ABCDEF0123456789"]
+        )
+        XCTAssertEqual(
+            authorizer.authorize(
+                method: "POST",
+                path: "/tools/mail_search",
+                authorizationHeader: "Bearer expected",
+                peer: peer(hash: "abcdef0123456789")
+            ),
+            .allow
+        )
+    }
+
+    func testAValidTokenFromAnotherBinaryIsForbiddenRatherThanUnauthorized() {
+        let decision = pinnedAuthorizer().authorize(
+            method: "POST",
+            path: "/tools/mail_search",
+            authorizationHeader: "Bearer expected",
+            peer: peer(hash: "2222222222222222222222222222222222222222")
+        )
+        guard case .deny(let status, let reason) = decision else {
+            return XCTFail("a copied token from another binary was allowed")
+        }
+        // 401 and 403 are different answers on purpose: the first says "configure a token", the
+        // second says "that token is not yours to use from there".
+        XCTAssertEqual(status, 403)
+        XCTAssertTrue(reason.contains("M3MCPBridge that ships with this app"), reason)
+        XCTAssertTrue(reason.contains("/Applications/M3MCP.app"), reason)
+    }
+
+    func testAPeerWithoutAVerifiableSignatureIsRefusedWhilePinningIsOn() {
+        let unsigned = pinnedAuthorizer().authorize(
+            method: "POST",
+            path: "/tools/mail_search",
+            authorizationHeader: "Bearer expected",
+            peer: peer(hash: nil)
+        )
+        XCTAssertEqual(unsigned, pinnedDenial(unsigned))
+
+        let tampered = pinnedAuthorizer().authorize(
+            method: "POST",
+            path: "/tools/mail_search",
+            authorizationHeader: "Bearer expected",
+            peer: peer(hash: bundledBridge, valid: false)
+        )
+        // The right hash with a failed validity check is still a refusal: validity is what catches a
+        // binary whose pages were changed after signing.
+        XCTAssertEqual(tampered, pinnedDenial(tampered))
+    }
+
+    private func pinnedDenial(_ decision: SocketAuthorizer.Decision) -> SocketAuthorizer.Decision {
+        guard case .deny(let status, let reason) = decision else {
+            XCTFail("expected a refusal")
+            return decision
+        }
+        XCTAssertEqual(status, 403)
+        XCTAssertTrue(reason.contains("no verifiable code signature"), reason)
+        return decision
+    }
+
+    /// A missing pin must be a stated fallback, not a silent one.
+    func testWithoutAPinTheTokenAloneDecidesAndTheStateSaysSo() {
+        let authorizer = SocketAuthorizer(token: "expected")
+        XCTAssertFalse(authorizer.pinsPeerIdentity)
+        XCTAssertTrue(authorizer.pinningDescription.contains("not pinned"), authorizer.pinningDescription)
+        XCTAssertEqual(
+            authorizer.authorize(
+                method: "POST",
+                path: "/tools/mail_search",
+                authorizationHeader: "Bearer expected",
+                peer: peer(hash: nil, valid: false)
+            ),
+            .allow
+        )
+        XCTAssertTrue(pinnedAuthorizer().pinsPeerIdentity)
+        XCTAssertTrue(
+            pinnedAuthorizer().pinningDescription.contains("pinned client"),
+            pinnedAuthorizer().pinningDescription
+        )
+    }
+
+    // MARK: - Against the real Security framework
+
+    func testThisProcessHasACodeDirectoryHashAndAFileOnDiskReportsTheSameOne() throws {
+        guard let running = PeerIdentity.codeDirectoryHashOfCurrentProcess() else {
+            throw XCTSkip("this test runner has no readable code signature")
+        }
+        XCTAssertEqual(running.count, 40, "a SHA-1-truncated code directory hash is 40 hex characters")
+
+        let executable = URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0])
+        guard let onDisk = PeerIdentity.codeDirectoryHash(ofFileAt: executable) else {
+            throw XCTSkip("the test runner executable at \(executable.path) has no readable signature")
+        }
+        XCTAssertEqual(running, onDisk, "the pin computed from a file must match the running process")
+    }
+
+    func testAPathThatIsNotAMachOBinaryYieldsNoHashRatherThanAWrongOne() throws {
+        let directory = URL(fileURLWithPath: "/private/tmp/m3pin-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let notABinary = directory.appendingPathComponent("M3MCPBridge")
+        try Data("not a binary".utf8).write(to: notABinary)
+
+        XCTAssertNil(PeerIdentity.codeDirectoryHash(ofFileAt: notABinary))
+    }
+
+    // MARK: - Resolving what to pin
+
+    func testTheSiblingBridgeIsWhatGetsPinned() throws {
+        // A signed Mach-O binary that is cheap to copy. The code directory hash is embedded in the
+        // file, so a copy of it reports the same hash, which is what makes the expectation exact.
+        let source = URL(fileURLWithPath: "/bin/echo")
+        guard let expected = PeerIdentity.codeDirectoryHash(ofFileAt: source) else {
+            throw XCTSkip("\(source.path) has no readable code signature on this machine")
+        }
+
+        let directory = URL(fileURLWithPath: "/private/tmp/m3trust-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // Stand in for an installed bundle: an app executable with a bridge next to it.
+        let app = directory.appendingPathComponent("M3MCPApp")
+        let bridge = directory.appendingPathComponent(TrustedClient.bridgeExecutableName)
+        try FileManager.default.copyItem(at: source, to: app)
+        try FileManager.default.copyItem(at: source, to: bridge)
+
+        let resolution = TrustedClient.resolve(appExecutableURL: app)
+        XCTAssertEqual(resolution.hashes, [expected])
+        XCTAssertTrue(resolution.note.contains(bridge.path), resolution.note)
+
+        // The pin follows the sibling: replace the bridge and the next resolution names the new one.
+        try FileManager.default.removeItem(at: bridge)
+        let replaced = TrustedClient.resolve(appExecutableURL: app)
+        XCTAssertTrue(replaced.hashes.isEmpty)
+        XCTAssertTrue(replaced.note.contains("no M3MCPBridge next to"), replaced.note)
+    }
+
+    func testAMissingSiblingBridgeIsReportedRatherThanQuietlyDroppingThePin() throws {
+        let directory = URL(fileURLWithPath: "/private/tmp/m3trust-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let app = directory.appendingPathComponent("M3MCPApp")
+        try Data("app".utf8).write(to: app)
+
+        let resolution = TrustedClient.resolve(appExecutableURL: app)
+        XCTAssertTrue(resolution.hashes.isEmpty)
+        XCTAssertTrue(resolution.note.contains("no M3MCPBridge next to"), resolution.note)
+
+        let unknownExecutable = TrustedClient.resolve(appExecutableURL: nil)
+        XCTAssertTrue(unknownExecutable.hashes.isEmpty)
+        XCTAssertTrue(unknownExecutable.note.contains("not pinned"), unknownExecutable.note)
+    }
+
+    func testTheEnvironmentOverrideReplacesTheSiblingLookup() throws {
+        guard ProcessInfo.processInfo.environment[TrustedClient.environmentKey] == nil else {
+            throw XCTSkip("\(TrustedClient.environmentKey) is already set in this environment")
+        }
+        setenv(TrustedClient.environmentKey, " AAAA , bbbb ,, ", 1)
+        defer { unsetenv(TrustedClient.environmentKey) }
+
+        let resolution = TrustedClient.resolve(appExecutableURL: nil)
+        XCTAssertEqual(resolution.hashes, ["aaaa", "bbbb"])
+        XCTAssertTrue(resolution.note.contains(TrustedClient.environmentKey), resolution.note)
+    }
+}

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -38,7 +38,8 @@ Relevant Apple documentation:
 
 - Use a Unix domain socket, not a loopback TCP port.
 - Keep the socket directory `0700`, the socket `0600`, and a restrictive creation `umask`.
-- Remember that `0600` is not authentication against another unsandboxed process with the same user ID. The capability token is; keep it out of shell history, logs, and shared configuration.
+- Remember that `0600` is not authentication against another unsandboxed process with the same user ID. The capability token and the client pin are; keep the token out of shell history, logs, and shared configuration.
+- Install the bridge next to the app executable. Without it the pin cannot be computed and the endpoint falls back to token-only, which `/health` and the app window report.
 - Unlink only the exact configured stale socket before binding.
 - Keep accepted-connection concurrency, request sizes, and blocked I/O time bounded.
 - Reject ambiguous framing: duplicate or invalid `Content-Length`, transfer encoding, trailing bytes, and malformed JSON.

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -38,7 +38,7 @@ Relevant Apple documentation:
 
 - Use a Unix domain socket, not a loopback TCP port.
 - Keep the socket directory `0700`, the socket `0600`, and a restrictive creation `umask`.
-- Remember that `0600` is not authentication against another unsandboxed process with the same user ID.
+- Remember that `0600` is not authentication against another unsandboxed process with the same user ID. The capability token is; keep it out of shell history, logs, and shared configuration.
 - Unlink only the exact configured stale socket before binding.
 - Keep accepted-connection concurrency, request sizes, and blocked I/O time bounded.
 - Reject ambiguous framing: duplicate or invalid `Content-Length`, transfer encoding, trailing bytes, and malformed JSON.

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -34,7 +34,21 @@ If the token cannot be read or created, the app does not start the listener. Com
 
 The bridge resolves the token on its first tool call and not at start-up, so `initialize` and `tools/list` are still answered by a bridge on a machine with no app, no keychain item, and no token. A keychain read from the bridge refuses interaction: an MCP client gives the bridge no session in which an authorization panel could be answered, and a panel there is indistinguishable from a server that never replies.
 
-What a token does not do: it is a secret in a file, and a copy of it works. It raises "connect to the socket", which every process of the user can do, to "be configured for this endpoint".
+What a token does not do: it is a secret in a file, and a copy of it works. It raises "connect to the socket", which every process of the user can do, to "be configured for this endpoint". The second factor covers the copy.
+
+### Pinned client binary
+
+At every start the app reads the code directory hash of the `M3MCPBridge` next to its own executable and accepts connections from that binary alone. A valid token from any other binary is refused with `403`. `M3MCP_TRUSTED_CLIENT_CDHASH` replaces the sibling lookup with an explicit comma-separated list; it is read from the server's environment, which only the person starting the server controls.
+
+The identity comes from the peer's audit token (`LOCAL_PEERTOKEN`) rather than its pid, because a pid can be recycled between `accept` and the lookup while a connection stays open through an asynchronous tool call. `SecCodeCheckValidity` runs as well as the hash comparison, so a binary whose pages were changed after signing is refused even when the recorded hash still matches.
+
+Why the hash and not a team identifier or a certificate: `swift build` produces an ad-hoc signature whose designated requirement is the hash itself, so for a source build there is nothing else to pin. `script/install_local.sh` and `script/package_release.sh` do sign with a stable certificate, which would make a leaf-certificate pin possible and would also make it weaker: `script/create_local_identity.sh` creates one self-signed certificate that signs every binary its owner signs, a hand-written socket client included. The hash does not go stale, because it is read at each start rather than compiled in, and an install replaces app and bridge together.
+
+Where no sibling bridge is found the pin cannot be computed. The app then runs token-only and reports that state in its window, in `source_status`, and in `/health`, rather than implying a protection that is not there.
+
+### Known limits
+
+The pin identifies a binary, not a caller. Any process that can start the bundled bridge and holds the token is a working client. The window between `connect` and the identity check is the time the request takes to arrive, so a process could in principle deliver a request and then become the pinned binary; that reaches only what the previous sentence already grants.
 
 The endpoint is not reachable from a web page because browsers cannot open Unix domain sockets. Origin-style request headers are also rejected as defense in depth.
 

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -116,8 +116,18 @@ Implemented limits include:
 - a nonblocking liveness probe for any pre-existing socket under one 250 ms absolute monotonic
   deadline; timeout, unexpected poll state, or another ambiguous error preserves the endpoint and
   fails startup instead of replacing it;
-- at most 16 accepted connections doing work at once;
-- a 15-second absolute request-receive deadline, even when a client trickles bytes;
+- two separate caps, because a connection that has said nothing and one that is being served do not
+  cost the same thing: at most 128 accepted connections waiting for a request, each costing a file
+  descriptor and a dispatch source and no thread, and at most 16 framed requests being served at
+  once, each holding a thread while its handler runs;
+- displacement rather than refusal at the waiting cap: the connection that has waited longest without
+  sending a byte yields its place to a new arrival, so filling every slot buys a silent process a
+  burst and not an outage. A connection that has sent something is work in progress and is never
+  displaced; when every slot holds one of those, a new arrival is refused with 503;
+- a listen backlog matched to the waiting cap, so a burst is queued rather than answered with
+  ECONNREFUSED, which a client cannot tell from a server that is not running;
+- a 15-second absolute request-receive deadline measured from `accept`, even when a client trickles
+  bytes or says nothing at all;
 - 15-second blocked read and write timeouts as defence in depth;
 - 32 KiB maximum HTTP header block;
 - 1,048,576-byte (1 MiB) maximum HTTP request body, matching the bridge's MCP message limit;

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -22,7 +22,19 @@ still governs enabled Calendar and Shortcut calls.
 
 The bridge explicitly supports MCP revisions `2024-11-05`, `2025-03-26`, `2025-06-18`, and `2025-11-25`. It requires the initialize response to be followed by the initialized notification before tools can be listed or called. Tool annotations are emitted for revisions that define them, and structured results are added for revisions that support them while retaining the text result for compatibility. Each incoming newline-delimited stdio message is limited to 1 MiB; bounded tool responses can be larger and use a separate 16 MiB stdout limit.
 
-The local operating-system account remains a trust boundary. The socket directory is `0700` and the socket is `0600`, which excludes other users and normally excludes sandboxed processes without access to that path. It does **not** authenticate another unsandboxed process running under the same user ID. Such a process can normally connect and exercise every tool enabled in the app process. Full Disk Access therefore raises the impact of compromise of any same-user unsandboxed process.
+The local operating-system account remains a trust boundary. The socket directory is `0700` and the socket is `0600`, which excludes other users and normally excludes sandboxed processes without access to that path. Filesystem permissions alone do **not** authenticate another unsandboxed process running under the same user ID, so the endpoint adds a capability token on top of them. See [Client authentication](#client-authentication). Full Disk Access raises the impact of compromise of any same-user unsandboxed process that holds a copy of the token.
+
+## Client authentication
+
+Every request other than `GET /health` must carry `Authorization: Bearer <token>`. `/health` stays open because it is the readiness probe `script/install_local.sh` waits on and it never carries the activity log.
+
+The token is 32 bytes from `SecRandomCopyBytes`, encoded as unpadded base64url so it survives an environment variable, a JSON configuration file, and an HTTP header unchanged. The app creates it on its first start and stores it in the login keychain as a generic password. `M3MCP_TOKEN` overrides the keychain in the app and in the bridge alike, which is how an MCP client is configured and how tests run without a keychain. Comparison is constant time in the token contents; the length is fixed by the generator and is allowed to leak.
+
+If the token cannot be read or created, the app does not start the listener. Coming up without one would put the endpoint back where it was.
+
+The bridge resolves the token on its first tool call and not at start-up, so `initialize` and `tools/list` are still answered by a bridge on a machine with no app, no keychain item, and no token. A keychain read from the bridge refuses interaction: an MCP client gives the bridge no session in which an authorization panel could be answered, and a panel there is indistinguishable from a server that never replies.
+
+What a token does not do: it is a secret in a file, and a copy of it works. It raises "connect to the socket", which every process of the user can do, to "be configured for this endpoint".
 
 The endpoint is not reachable from a web page because browsers cannot open Unix domain sockets. Origin-style request headers are also rejected as defense in depth.
 

--- a/index.html
+++ b/index.html
@@ -258,8 +258,9 @@ gh attestation verify M3MCP.app.zip \
   --signer-workflow GodModeAI2025/AppleMCP/.github/workflows/release.yml  # optional
 unzip M3MCP.app.zip
 
-# Point the MCP client at the bridge inside the bundle
-claude mcp add applemcp /absolute/path/M3MCP.app/Contents/MacOS/M3MCPBridge</code></pre>
+# Point the MCP client at the bridge inside the bundle. The app accepts only the
+# M3MCPBridge next to its own executable, and the token comes from Server &gt; Copy MCP Client Token.
+claude mcp add applemcp -e M3MCP_TOKEN=&lt;token&gt; -- /absolute/path/M3MCP.app/Contents/MacOS/M3MCPBridge</code></pre>
             <p style="margin-top: 16px;"><strong>Candidate status.</strong> The automated build is Apple Silicon only (<code>arm64</code>), ad-hoc signed, and unnotarized. It is not a production-grade macOS distribution.</p>
             <p style="margin-top: 12px;"><strong>Verification has limits.</strong> The checksum detects a mismatch against the asset recorded in the same GitHub release; alone it does not establish independent publisher authenticity. GitHub provenance binds the ZIP to this repository's workflow, but does not replace Apple Developer ID signing and notarization.</p>
             <p style="margin-top: 12px;"><strong>Respect Gatekeeper.</strong> If macOS blocks the app, verify its origin first and use System Settings, Privacy &amp; Security → <strong>Open Anyway</strong> only when you trust the candidate. Do not remove quarantine metadata merely to bypass the warning.</p>
@@ -279,13 +280,18 @@ swift test
 {
   "mcpServers": {
     "applemcp": {
-      "command": "/path/to/AppleMCP/.build/debug/M3MCPBridge"
+      "command": "/path/to/AppleMCP/.build/debug/M3MCPBridge",
+      "env": { "M3MCP_TOKEN": "&lt;token from the app: Server &gt; Copy MCP Client Token&gt;" }
     }
   }
 }
 
 # Or add to Claude Code
-claude mcp add applemcp /path/to/AppleMCP/.build/debug/M3MCPBridge
+claude mcp add applemcp -e M3MCP_TOKEN=&lt;token&gt; -- /path/to/AppleMCP/.build/debug/M3MCPBridge
+
+# Use the bridge next to the app you actually run: dist/M3MCP.app/Contents/MacOS/M3MCPBridge
+# after build_and_run.sh, ~/Applications/M3MCP.app/Contents/MacOS/M3MCPBridge after install_local.sh.
+# A copy from anywhere else has a different code directory hash and is refused with 403.
 
 # Check the endpoint
 curl --unix-socket ~/Library/Application\ Support/M3MCP/mcp.sock \

--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
                 </div>
                 <div class="card">
                     <h3>Honest local boundary</h3>
-                    <p>The socket is owner-only, but an unsandboxed process running as the same user can normally connect. Full Disk Access raises that trust requirement.</p>
+                    <p>The socket is owner-only, and every route but <code>/health</code> also needs the capability token the app keeps in the login keychain. A copied token still works, so treat every configured client as trusted.</p>
                 </div>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
                 </div>
                 <div class="card">
                     <h3>Honest local boundary</h3>
-                    <p>The socket is owner-only, and every route but <code>/health</code> also needs the capability token the app keeps in the login keychain. A copied token still works, so treat every configured client as trusted.</p>
+                    <p>The socket is owner-only, every route but <code>/health</code> needs the capability token from the login keychain, and the connecting binary is pinned to the <code>M3MCPBridge</code> installed next to the app. The pin identifies a binary, not a caller, so treat every configured client as trusted.</p>
                 </div>
             </div>
         </section>

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 MODE="${1:-run}"
 APP_NAME="M3MCPApp"
+BRIDGE_NAME="M3MCPBridge"
 BUNDLE_NAME="M3MCP"
 BUNDLE_ID="de.markzimmermann.m3mcp"
 MIN_SYSTEM_VERSION="15.0"
@@ -14,6 +15,7 @@ APP_BUNDLE="$DIST_DIR/$BUNDLE_NAME.app"
 APP_CONTENTS="$APP_BUNDLE/Contents"
 APP_MACOS="$APP_CONTENTS/MacOS"
 APP_BINARY="$APP_MACOS/$APP_NAME"
+BRIDGE_BINARY="$APP_MACOS/$BRIDGE_NAME"
 INFO_PLIST="$APP_CONTENTS/Info.plist"
 SOURCE_INFO_PLIST="$ROOT_DIR/Sources/M3MCPApp/Resources/Info.plist"
 source "$ROOT_DIR/script/signing_identity.sh"
@@ -36,12 +38,18 @@ pick_identity() {
 pkill -x "$APP_NAME" >/dev/null 2>&1 || true
 
 swift build
-BUILD_BINARY="$(swift build --show-bin-path)/$APP_NAME"
+BIN_PATH="$(swift build --show-bin-path)"
+BUILD_BINARY="$BIN_PATH/$APP_NAME"
+BUILD_BRIDGE="$BIN_PATH/$BRIDGE_NAME"
 
 rm -rf "$APP_BUNDLE"
 mkdir -p "$APP_MACOS"
 cp "$BUILD_BINARY" "$APP_BINARY"
 chmod +x "$APP_BINARY"
+# The app pins the client it accepts to the M3MCPBridge next to its own executable. Without this
+# copy every run of this script would be token-only, and the app window would say so.
+cp "$BUILD_BRIDGE" "$BRIDGE_BINARY"
+chmod +x "$BRIDGE_BINARY"
 cp "$SOURCE_INFO_PLIST" "$INFO_PLIST"
 /usr/bin/xattr -cr "$APP_BUNDLE" >/dev/null 2>&1 || true
 

--- a/script/install_local.sh
+++ b/script/install_local.sh
@@ -18,6 +18,7 @@
 set -euo pipefail
 
 APP_NAME="M3MCPApp"
+BRIDGE_NAME="M3MCPBridge"
 BUNDLE_NAME="M3MCP"
 BUNDLE_ID="de.markzimmermann.m3mcp"
 CONFIGURATION="${M3MCP_CONFIGURATION:-release}"
@@ -29,6 +30,7 @@ source "$ROOT_DIR/script/lib/codesign.sh"
 
 APP_BUNDLE="$INSTALL_DIR/$BUNDLE_NAME.app"
 APP_BINARY="$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+BRIDGE_BINARY="$APP_BUNDLE/Contents/MacOS/$BRIDGE_NAME"
 AGENT_PLIST="$HOME/Library/LaunchAgents/$BUNDLE_ID.plist"
 AGENT_DIR="${AGENT_PLIST%/*}"
 SOURCE_INFO_PLIST="$ROOT_DIR/Sources/$APP_NAME/Resources/Info.plist"
@@ -307,8 +309,11 @@ echo "Signing identity: $IDENTITY"
 echo "Building ($CONFIGURATION)…"
 cd "$ROOT_DIR"
 swift build -c "$CONFIGURATION"
-BUILT_BINARY="$(swift build -c "$CONFIGURATION" --show-bin-path)/$APP_NAME"
+BIN_PATH="$(swift build -c "$CONFIGURATION" --show-bin-path)"
+BUILT_BINARY="$BIN_PATH/$APP_NAME"
+BUILT_BRIDGE="$BIN_PATH/$BRIDGE_NAME"
 [[ -x "$BUILT_BINARY" ]] || { echo "Build produced no binary at $BUILT_BINARY" >&2; exit 1; }
+[[ -x "$BUILT_BRIDGE" ]] || { echo "Build produced no bridge at $BUILT_BRIDGE" >&2; exit 1; }
 
 # --- assemble and validate replacements --------------------------------------------------------
 
@@ -317,10 +322,16 @@ mkdir -p "$INSTALL_DIR"
 STAGING_ROOT="$(mktemp -d "$INSTALL_DIR/.$BUNDLE_NAME.install.XXXXXX")"
 STAGED_APP="$STAGING_ROOT/$BUNDLE_NAME.app"
 STAGED_APP_BINARY="$STAGED_APP/Contents/MacOS/$APP_NAME"
+STAGED_BRIDGE_BINARY="$STAGED_APP/Contents/MacOS/$BRIDGE_NAME"
 
 mkdir -p "$STAGED_APP/Contents/MacOS"
 cp "$BUILT_BINARY" "$STAGED_APP_BINARY"
 chmod +x "$STAGED_APP_BINARY"
+# The bridge goes in beside the app, the same way script/package_release.sh puts it there. The app
+# pins the client it accepts to the M3MCPBridge next to its own executable, so an installation
+# without this file falls back to token-only and says so in its window and in /health.
+cp "$BUILT_BRIDGE" "$STAGED_BRIDGE_BINARY"
+chmod +x "$STAGED_BRIDGE_BINARY"
 cp "$SOURCE_INFO_PLIST" "$STAGED_APP/Contents/Info.plist"
 printf 'APPL????' > "$STAGED_APP/Contents/PkgInfo"
 xattr -cr "$STAGED_APP" 2>/dev/null || true
@@ -328,6 +339,9 @@ xattr -cr "$STAGED_APP" 2>/dev/null || true
 
 # --- sign -------------------------------------------------------------------------------------
 
+# Nested code first, then the main executable, then the bundle: a later signature seals what came
+# before it.
+codesign --force --sign "$IDENTITY" "$STAGED_BRIDGE_BINARY" >/dev/null
 codesign --force --sign "$IDENTITY" "$STAGED_APP_BINARY" >/dev/null
 codesign --force --sign "$IDENTITY" "$STAGED_APP" >/dev/null
 codesign --verify --strict "$STAGED_APP"
@@ -392,6 +406,7 @@ if ! mv -- "$STAGED_APP" "$APP_BUNDLE"; then
   exit 1
 fi
 [[ -x "$APP_BINARY" ]] || { echo "Installed bundle has no executable at $APP_BINARY" >&2; exit 1; }
+[[ -x "$BRIDGE_BINARY" ]] || { echo "Installed bundle has no bridge at $BRIDGE_BINARY" >&2; exit 1; }
 codesign --verify --strict "$APP_BUNDLE"
 
 if path_exists "$AGENT_PLIST"; then
@@ -431,6 +446,13 @@ echo "  $APP_BUNDLE"
 echo "then restart it:  launchctl kickstart -k gui/$UID/$BUNDLE_ID"
 echo
 echo "Because the signature uses a stable certificate, that grant persists across future rebuilds."
+echo
+echo "Point your MCP client at the bridge that was installed with the app:"
+echo "  $BRIDGE_BINARY"
+echo "and give it the capability token from the app's Server menu (Copy MCP Client Token):"
+echo '  "env": { "M3MCP_TOKEN": "<token>" }'
+echo "Without the token the app refuses every tool call. A bridge from anywhere else is refused too:"
+echo "the app accepts only the code directory hash of the bridge sitting next to it."
 echo
 echo "Manage:"
 echo "  launchctl kickstart -k gui/$UID/$BUNDLE_ID   # restart"


### PR DESCRIPTION
## Socket-Authentifizierung auf dem aktuellen Stand

Der Unix-Socket war bisher nur durch Dateirechte geschuetzt: `0700`-Verzeichnis, `0600`-Socket. Das haelt andere Benutzer und Sandbox-Apps draussen und sonst nichts. Jeder unsandboxed Prozess desselben Benutzers konnte sich verbinden und den Full Disk Access der App erben. Dieser Zweig macht daraus drei Dinge, in dieser Reihenfolge gebaut und einzeln lauffaehig.

Der Zweig ist von `origin/main` neu aufgesetzt und nicht mit `feat/welle-5` gemergt. Ein Merge haette 13 Konflikte gehabt, darunter einen strukturellen um `LocalHTTPServer.swift`, bei dem in jeder Aufloesungsrichtung Sicherheitsarbeit verloren gegangen waere. Die Arbeit aus PR #17 ist vollstaendig erhalten.

### 1. Capability-Token

32 Bytes aus `SecRandomCopyBytes`, base64url ohne Padding, beim ersten Start erzeugt und im Login-Schluesselbund abgelegt. Konstantzeitiger Vergleich. `M3MCP_TOKEN` sticht den Schluesselbund in App und Bridge, damit ein MCP-Client konfigurierbar bleibt und Tests ohne entsperrten Schluesselbund laufen. Laesst sich kein Token lesen oder anlegen, startet der Listener gar nicht: mit offenem Endpunkt weiterzumachen waere der Zustand von vorher.

Die Bridge loest das Token erst beim ersten Werkzeugaufruf auf. `initialize` und `tools/list` beantwortet sie aus dem Katalog, ohne die App zu beruehren, und genau das tut `script/check_release_artifact.sh` auf einer Maschine ohne App, ohne Schluesselbundeintrag und ohne Token.

`GET /health` bleibt offen, weil der Installer darauf wartet. `/status` nicht mehr: es traegt den Aktivitaetslog mit Werkzeug-Eingaben und begrenzten Ausgaben.

### 2. Peer-Pin

Ein Token ist ein Geheimnis in einer Datei, eine Kopie davon funktioniert. Deshalb prueft die App zusaetzlich die Binary am anderen Ende: bei jedem Start liest sie den Code-Directory-Hash der `M3MCPBridge` neben ihrer eigenen ausfuehrbaren Datei und nimmt nur diese an. Gueltiges Token aus einer anderen Binary ist `403`, fehlendes oder falsches Token `401`.

Die Identitaet kommt aus dem Audit-Token der Gegenstelle, nicht aus der Prozess-ID: eine ID kann zwischen `accept` und Nachschlagen wiederverwendet sein, und die Verbindung bleibt hier durch einen asynchronen Werkzeugaufruf hindurch offen.

Warum der Hash und kein Zertifikat, gemessen auf diesem Stand: `swift build` signiert ad hoc, `codesign -d -r-` meldet als Designated Requirement woertlich `cdhash H"..."`. Fuer den Quellbau gibt es nichts anderes. `install_local.sh` und `package_release.sh` signieren mit stabilem Zertifikat, ein Zertifikats-Pin waere also moeglich und waere schwaecher: `create_local_identity.sh` legt ein einziges selbstsigniertes Zertifikat an, das jede Binary seines Besitzers signiert, auch einen selbst geschriebenen Socket-Client. Der Hash veraltet nicht, weil er bei jedem Start gelesen und nicht einkompiliert wird.

Der Pin identifiziert eine Binary, keinen Aufrufer. Wer die mitgelieferte Bridge starten kann und das Token hat, bleibt ein gueltiger Client. Das steht in `SECURITY.md` und in `docs/SECURITY_MODEL.md` unter Known limits.

### 3. Verhalten unter Last

Autorisierung kann erst stattfinden, wenn die Anfrage ganz gelesen ist, denn das Token ist eine Kopfzeile. Damit gehoert die Verfuegbarkeit zur Zugriffskontrolle. Vorher genuegten 16 stille Verbindungen, um den Endpunkt fuer jeden zu schliessen, `/health` eingeschlossen.

Eine angenommene Verbindung wird jetzt ueber eine Dispatch-Quelle auf einer seriellen Queue gelesen statt von einem Thread, der in `read` parkt. Zwei Grenzen statt einer: 128 wartende Verbindungen, 16 gleichzeitig bediente Anfragen. An der Wartegrenze verliert die Verbindung ihren Platz, die am laengsten kein Byte geschickt hat, nicht der Neuankoemmling. Eine Verbindung, die schon etwas gesendet hat, ist angefangene Arbeit und wird nie verdraengt.

Die Verwaltung laufender Anfragen aus PR #17 bleibt unangetastet: Start-Lock, Socket-Probe, `ActiveConnectionRegistry`, `RequestCancellationState`, `PeerDisconnectMonitor`, absolute Schreibfristen, Antwortgroessengrenze. Die Eigentuemerregel bleibt: genau einer schliesst jeden Deskriptor, `stop()` macht nur `shutdown`.

### Messung, dieselben Proben gegen beide Staende

| Probe | origin/main (ec572df) | dieser Zweig |
|---|---|---|
| Werkzeugaufruf ohne Token | 200 | 401 |
| Werkzeugaufruf mit Token | 200 | 200 |
| Token aus fremder Binary (python3) | 200 | 403 |
| Echte Bridge mit Token | ok | ok |
| 16 stille Verbindungen, /health | 503 bzw. ECONNREFUSED | 200 |
| 400 stille Verbindungen, /health | 503 | 200 |
| Dauerflut 8s, Anteil 200 | 2 % | 99 % |

### Test und CI

325 Tests, 0 Fehler (vorher 289). Alle Schritte aus `ci.yml` lokal gruen, ThreadSanitizer ohne Warnung. Die drei neuen Socket-Testklassen sind in den TSan-Filter aufgenommen, weil sich der Aufnahmepfad geaendert hat.

### Was ein Betreiber merkt

Ein bestehender MCP-Client hoert ohne Token auf zu funktionieren und bekommt eine Meldung, die sagt, was zu tun ist. Der Client muss auf die Bridge **neben der laufenden App** zeigen; nach einer Installation ist das `~/Applications/M3MCP.app/Contents/MacOS/M3MCPBridge` und nicht mehr `.build/release/M3MCPBridge`, weil der Installer die gestagte Kopie neu signiert. README und Landingpage nennen das jetzt fuer jeden Startweg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL7UoPomBp2Luhg89R6fYk

---

## Warum portiert statt gemergt

Der Vorgaengerzweig `feat/welle-5` (PR #18) hat dieselbe Arbeit auf `41872fe` gebaut. Waehrend sie
lief, wurde PR #17 mit rund 24000 Zeilen gemergt. `git merge-tree` meldete danach 13 Konflikte, einer
davon strukturell: `LocalHTTPServer.swift` war auf dem alten Zweig geloescht und auf `main` um rund
1100 Zeilen gewachsen. Welche Seite ein Aufloeser behalten haette, es waere Sicherheitsarbeit verloren
gegangen. Dieser Zweig zweigt deshalb von `ec572df` ab und baut die drei Stuecke dort nach, ohne einen
einzigen Konflikt.

## Von der Abnahme selbst gemessen

- Token und Pin ueber einen echten Unix-Socket, nicht ueber das Werkzeugschema: ohne Token 401, mit
  Token 200, `/health` offen. Die echte Bridge kommt mit Token durch, `python3` mit demselben
  gueltigen Token bekommt 403.
- Zwoelf Umgehungsversuche gegen den gepinnten Server laufen ins Leere, darunter Pfad-Tricks auf
  `/health`, ein Praefix-Token und ein doppelter Authorization-Header.
- Die Arbeit aus PR #17 ist unbeschaedigt: keine geloeschte Datei, `MailProvider`, `LocalMCPService`
  und `ToolCatalog` sind byte-identisch zu `main`, an den dortigen Tests wurde keine einzige
  Zusicherung geaendert.
- 325 Tests ohne Fehler, ThreadSanitizer ohne Warnung, der Release-Kandidat baut byte-reproduzierbar.

## Was offen bleibt, benannt statt verschwiegen

Beides steht unter Known limits in `SECURITY.md`, nicht nur hier:

- Ohne die Bridge neben der App faellt der Server auf Token-only zurueck. Eine fremde Binary mit
  kopiertem Token kommt dann durch.
- Der Pin identifiziert eine Binary, keinen Aufrufer. Wer die mitgelieferte Bridge starten kann und
  das Token hat, bleibt ein gueltiger Client.

Beantwortet Issue #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL7UoPomBp2Luhg89R6fYk
