### PR TITLE
Zeitschranken der Nebenlaeufigkeitstests unter dem Sanitizer dehnen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,12 @@ jobs:
         run: swift test
 
       - name: Run concurrency security tests with ThreadSanitizer
+        env:
+          # ThreadSanitizer verlangsamt um ein Vielfaches. Ohne diesen Faktor werden die
+          # Zeitschranken der Nebenlaeufigkeitstests zur Wette auf die Auslastung des
+          # Runners: am 5. September lieferte derselbe Commit einen gruenen und einen
+          # roten Lauf, waehrend der Test lokal zehnmal hintereinander bestand.
+          M3MCP_TIMING_SLACK: "20"
         run: >-
           swift test --sanitize=thread --filter
           'PermissionProviderCancellationTests|RemindersProviderCancellationTests|LegacySpeechRecognizerCancellationTests|SpeechPrivacyPolicyTests|NativeToolApprovalCoordinatorTests|AppleScriptRunnerCancellationTests|AutomationPermissionPreflightTests|MailProviderCancellationTests|MailProviderSQLiteSecurityTests|LocalHTTPServerCancellationTests|LocalHTTPServerStartLockTests|MCPServerFormattingTests|LocalHTTPResponseTests|InFlightRequestRegistryTests|BoundedProcessRunnerTests|SensitiveTemporaryArtifactsTests|AppStartupCleanupTests|ShortcutRunnerTests|VoiceMemosRecordingSecurityTests|VoiceMemosSnapshotSecurityTests|SocketAuthenticationTests|SocketPeerPinTests|SocketAvailabilityTests'

--- a/Tests/M3MCPAppTests/LegacySpeechRecognizerCancellationTests.swift
+++ b/Tests/M3MCPAppTests/LegacySpeechRecognizerCancellationTests.swift
@@ -31,7 +31,7 @@ final class LegacySpeechRecognizerCancellationTests: XCTestCase {
         let elapsed = Double(
             DispatchTime.now().uptimeNanoseconds - started
         ) / 1_000_000_000
-        XCTAssertLessThan(elapsed, 0.15)
+        XCTAssertLessThan(elapsed, zeitbudget(0.15))
         XCTAssertEqual(admission.activeOperationCount, 1)
 
         do {

--- a/Tests/M3MCPAppTests/ZeitbudgetHelfer.swift
+++ b/Tests/M3MCPAppTests/ZeitbudgetHelfer.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Zeitschranken in Tests, die unter einem Sanitizer nicht zum Zufallsgenerator werden.
+///
+/// ThreadSanitizer verlangsamt die Ausfuehrung um ein Vielfaches. Eine Schranke, die ohne
+/// Sanitizer aussagekraeftig ist, wird darunter zur Wette auf die Auslastung des Runners.
+/// Gemessen am 5. September 2026: derselbe Commit lieferte auf demselben Runner einen gruenen
+/// und einen roten Lauf, waehrend der betroffene Test lokal zehnmal hintereinander bestand.
+///
+/// `M3MCP_TIMING_SLACK` traegt den Faktor, um den eine Schranke gedehnt wird. Die CI setzt ihn
+/// im Sanitizer-Schritt. Ohne die Variable bleibt die Schranke unveraendert, der Test misst
+/// also im Normalfall genau das, was er vorher gemessen hat.
+func zeitbudget(_ sekunden: Double) -> Double {
+    guard let roh = ProcessInfo.processInfo.environment["M3MCP_TIMING_SLACK"],
+          let faktor = Double(roh), faktor > 0 else {
+        return sekunden
+    }
+    return sekunden * faktor
+}

--- a/Tests/M3MCPBridgeTests/MCPServerFormattingTests.swift
+++ b/Tests/M3MCPBridgeTests/MCPServerFormattingTests.swift
@@ -468,7 +468,7 @@ final class MCPServerFormattingTests: XCTestCase {
         XCTAssertEqual(response.source, "M3MCPBridge")
         XCTAssertTrue(response.message?.contains("Reading from the local socket failed") == true)
         XCTAssertGreaterThanOrEqual(elapsed, 0.8)
-        XCTAssertLessThan(elapsed, 3)
+        XCTAssertLessThan(elapsed, zeitbudget(3))
         XCTAssertEqual(fixture.peerClosed.wait(timeout: .now() + 2), .success)
     }
 
@@ -487,7 +487,7 @@ final class MCPServerFormattingTests: XCTestCase {
         XCTAssertFalse(response.ok)
         XCTAssertTrue(response.message?.contains("absolute response deadline") == true)
         XCTAssertGreaterThanOrEqual(elapsed, 0.15)
-        XCTAssertLessThan(elapsed, 1.5)
+        XCTAssertLessThan(elapsed, zeitbudget(1.5))
         XCTAssertEqual(fixture.peerClosed.wait(timeout: .now() + 2), .success)
     }
 

--- a/Tests/M3MCPBridgeTests/ZeitbudgetHelfer.swift
+++ b/Tests/M3MCPBridgeTests/ZeitbudgetHelfer.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Zeitschranken in Tests, die unter einem Sanitizer nicht zum Zufallsgenerator werden.
+///
+/// ThreadSanitizer verlangsamt die Ausfuehrung um ein Vielfaches. Eine Schranke, die ohne
+/// Sanitizer aussagekraeftig ist, wird darunter zur Wette auf die Auslastung des Runners.
+/// Gemessen am 5. September 2026: derselbe Commit lieferte auf demselben Runner einen gruenen
+/// und einen roten Lauf, waehrend der betroffene Test lokal zehnmal hintereinander bestand.
+///
+/// `M3MCP_TIMING_SLACK` traegt den Faktor, um den eine Schranke gedehnt wird. Die CI setzt ihn
+/// im Sanitizer-Schritt. Ohne die Variable bleibt die Schranke unveraendert, der Test misst
+/// also im Normalfall genau das, was er vorher gemessen hat.
+func zeitbudget(_ sekunden: Double) -> Double {
+    guard let roh = ProcessInfo.processInfo.environment["M3MCP_TIMING_SLACK"],
+          let faktor = Double(roh), faktor > 0 else {
+        return sekunden
+    }
+    return sekunden * faktor
+}

--- a/Tests/M3MCPCoreTests/SpeechPrivacyPolicyTests.swift
+++ b/Tests/M3MCPCoreTests/SpeechPrivacyPolicyTests.swift
@@ -135,7 +135,7 @@ final class SpeechPrivacyPolicyTests: XCTestCase {
         }
 
         let elapsed = Double(DispatchTime.now().uptimeNanoseconds - started) / 1_000_000_000
-        XCTAssertLessThan(elapsed, 1)
+        XCTAssertLessThan(elapsed, zeitbudget(1))
         XCTAssertEqual(admission.activeOperationCount, 0)
     }
 
@@ -162,7 +162,7 @@ final class SpeechPrivacyPolicyTests: XCTestCase {
         }
 
         let elapsed = Double(DispatchTime.now().uptimeNanoseconds - started) / 1_000_000_000
-        XCTAssertLessThan(elapsed, 0.15)
+        XCTAssertLessThan(elapsed, zeitbudget(0.15))
         XCTAssertEqual(admission.activeOperationCount, 1)
 
         do {
@@ -211,7 +211,7 @@ final class SpeechPrivacyPolicyTests: XCTestCase {
         }
 
         let elapsed = Double(DispatchTime.now().uptimeNanoseconds - started) / 1_000_000_000
-        XCTAssertLessThan(elapsed, 0.15)
+        XCTAssertLessThan(elapsed, zeitbudget(0.15))
         XCTAssertEqual(admission.activeOperationCount, 1)
         try? await Task.sleep(nanoseconds: 350_000_000)
         XCTAssertEqual(admission.activeOperationCount, 0)

--- a/Tests/M3MCPCoreTests/ZeitbudgetHelfer.swift
+++ b/Tests/M3MCPCoreTests/ZeitbudgetHelfer.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Zeitschranken in Tests, die unter einem Sanitizer nicht zum Zufallsgenerator werden.
+///
+/// ThreadSanitizer verlangsamt die Ausfuehrung um ein Vielfaches. Eine Schranke, die ohne
+/// Sanitizer aussagekraeftig ist, wird darunter zur Wette auf die Auslastung des Runners.
+/// Gemessen am 5. September 2026: derselbe Commit lieferte auf demselben Runner einen gruenen
+/// und einen roten Lauf, waehrend der betroffene Test lokal zehnmal hintereinander bestand.
+///
+/// `M3MCP_TIMING_SLACK` traegt den Faktor, um den eine Schranke gedehnt wird. Die CI setzt ihn
+/// im Sanitizer-Schritt. Ohne die Variable bleibt die Schranke unveraendert, der Test misst
+/// also im Normalfall genau das, was er vorher gemessen hat.
+func zeitbudget(_ sekunden: Double) -> Double {
+    guard let roh = ProcessInfo.processInfo.environment["M3MCP_TIMING_SLACK"],
+          let faktor = Double(roh), faktor > 0 else {
+        return sekunden
+    }
+    return sekunden * faktor
+}


### PR DESCRIPTION
Behebt einen wackeligen Test, der `main` rot gemacht hat, ohne dass etwas kaputt war.

**Der Befund.** Lauf 33935218159 auf `main` schlug fehl an
`SpeechPrivacyPolicyTests.testDeadlineReturnsWhileCancellationIgnoringChildFinishesUnderAdmissionLease`.
Derselbe Commit `ccc68b3e` hat auf demselben Runner einen gruenen und einen roten Lauf, und lokal
besteht der Test zehnmal hintereinander. Der Test setzt eine Frist von 0,02 Sekunden und prueft
danach, dass weniger als 0,15 Sekunden vergangen sind. Unter ThreadSanitizer, der um ein Vielfaches
verlangsamt, ist das keine Messung mehr, sondern eine Wette auf die Auslastung des Runners.

**Die Aenderung.** Die sechs harten Zeitschranken in den Nebenlaeufigkeitstests lesen jetzt
`M3MCP_TIMING_SLACK`. Die CI setzt den Faktor nur im Sanitizer-Schritt. Ohne die Variable bleibt die
Schranke unveraendert, im normalen Testlauf misst also alles genau wie vorher.

**Warum nicht einfach die Schranke lockern.** Dann waere sie auch im normalen Lauf stumpf. So misst
sie dort weiter scharf, und nur der Sanitizer bekommt die Luft, die er braucht.

## Geprueft

| Fall | erwartet | Ergebnis |
|---|---|---|
| Volle Suite ohne Faktor | gruen | 325 Tests, 0 Fehler |
| Betroffene Klasse mit Faktor 20 | gruen | 13 Tests, 0 Fehler |
| Schranke kuenstlich auf 0,0001 s, ohne Faktor | rot | rot |
| Schranke kuenstlich auf 0,0001 s, mit Faktor 20 | rot | rot |

Die letzten beiden Zeilen belegen, dass die Schranke weiterhin misst und der Faktor sie nicht
stumpf macht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL7UoPomBp2Luhg89R6fYk
