### PR TITLE
Kalenderschreibvorgaenge vorschaubar und ruecknehmbar machen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           M3MCP_TIMING_SLACK: "20"
         run: >-
           swift test --sanitize=thread --filter
-          'PermissionProviderCancellationTests|RemindersProviderCancellationTests|LegacySpeechRecognizerCancellationTests|SpeechPrivacyPolicyTests|NativeToolApprovalCoordinatorTests|AppleScriptRunnerCancellationTests|AutomationPermissionPreflightTests|MailProviderCancellationTests|MailProviderSQLiteSecurityTests|LocalHTTPServerCancellationTests|LocalHTTPServerStartLockTests|MCPServerFormattingTests|LocalHTTPResponseTests|InFlightRequestRegistryTests|BoundedProcessRunnerTests|SensitiveTemporaryArtifactsTests|AppStartupCleanupTests|ShortcutRunnerTests|VoiceMemosRecordingSecurityTests|VoiceMemosSnapshotSecurityTests|SocketAuthenticationTests|SocketPeerPinTests|SocketAvailabilityTests'
+          'PermissionProviderCancellationTests|RemindersProviderCancellationTests|LegacySpeechRecognizerCancellationTests|SpeechPrivacyPolicyTests|NativeToolApprovalCoordinatorTests|AppleScriptRunnerCancellationTests|AutomationPermissionPreflightTests|MailProviderCancellationTests|MailProviderSQLiteSecurityTests|LocalHTTPServerCancellationTests|LocalHTTPServerStartLockTests|MCPServerFormattingTests|LocalHTTPResponseTests|InFlightRequestRegistryTests|BoundedProcessRunnerTests|SensitiveTemporaryArtifactsTests|AppStartupCleanupTests|ShortcutRunnerTests|VoiceMemosRecordingSecurityTests|VoiceMemosSnapshotSecurityTests|SocketAuthenticationTests|SocketPeerPinTests|SocketAvailabilityTests|CalendarUndoJournalTests|CalendarDryRunDispatchTests'
 
       - name: Build release binaries
         run: swift build -c release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@
   rules, and travel time are outside it; tokens are single-use, expire after 30 minutes, are capped
   at the 20 most recent writes, and are held in memory only, so they do not survive a restart of the
   app; and deleting a calendar still has no undo, which is what its two matching keys are for.
+- **Mail search has tests that read a Mail store.** The provider with the largest surface in the
+  repo, and the thinnest coverage, now runs against a synthetic Envelope Index with the
+  `subjects`/`addresses`/`recipients` lookup schema and real `.emlx` files on disk, redirected
+  through `M3MCP_MAIL_ROOT`. Pinned: `match` of `all`, `any`, and `phrase`, including that a phrase
+  keeps a word order that `all` throws away; that an address behind a display name stays findable;
+  that recipients are matched through their own table and only when asked for; that a body-only hit
+  survives being requested next to a subject; that deleted, junk, and read filtering happens in SQL;
+  that `since_hours` understands both the Unix-epoch and the reference-date encoding of the same
+  column; that a mailbox url resolving outside the mail root yields no file from outside it; and how
+  a mailbox url is split into account, path, and role, in English and in German.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+### Added
+
+- **`dry_run` on every calendar write.** `calendar_create_event`, `calendar_update_event`,
+  `calendar_delete_event`, `calendar_create_calendar`, and `calendar_delete_calendar` take a
+  `dry_run` boolean. With `dry_run: true` the tool resolves the calendar, parses the timestamps,
+  runs every validation rule, works out which fields would change, answers with
+  `meta.dry_run = "true"`, and writes nothing. Such a call shows no approval sheet, because nothing
+  is being approved; the launch opt-in still gates the group, and a preview reveals nothing the
+  default-safe read tools do not. Only the literal boolean `true` selects a preview, so `"true"`,
+  `1`, and an absent value all keep the previous behaviour.
+- **Undo for the three event writes.** Create, update, and delete now record what they replaced
+  before they commit and return `meta.undo_token`. The new `calendar_undo_write` tool spends that
+  token: it removes an event that was created, writes the previous values back over the fields an
+  update changed, and rebuilds a deleted event from the snapshot taken just before it went.
+  `dry_run: true` on the undo reports the plan and leaves the token unspent, and a failed undo
+  changes nothing and keeps the token valid. Undo is itself a calendar mutation, so it needs the
+  same `M3MCP_ENABLE_CALENDAR_MUTATIONS=1` opt-in and its own approval sheet.
+
+  What it does not cover is documented next to it, in the README and in `docs/SECURITY_MODEL.md`, and
+  reported per call in `meta`: a rebuilt event has a new id; recurring events and
+  `span: "future_events"` get no token at all, only `meta.undo_unavailable` with the reason; only
+  fields these tools can write are restored, so attendees, attachments, availability, recurrence
+  rules, and travel time are outside it; tokens are single-use, expire after 30 minutes, are capped
+  at the 20 most recent writes, and are held in memory only, so they do not survive a restart of the
+  app; and deleting a calendar still has no undo, which is what its two matching keys are for.
+
 ### Security
 
 - **Capability token on the socket.** The app generates a 32-byte secret on its first start, keeps it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,15 @@
   fields these tools can write are restored, so attendees, attachments, availability, recurrence
   rules, and travel time are outside it; tokens are single-use, expire after 30 minutes, are capped
   at the 20 most recent writes, and are held in memory only, so they do not survive a restart of the
-  app; and deleting a calendar still has no undo, which is what its two matching keys are for.
+  app; and deleting a calendar still has no undo, which is what its two matching keys are for. An
+  alarm pinned to an absolute date is outside the restored set as well, because these tools only ever
+  create relative ones.
+- **The undo approval sheet shows the effect, not the token.** `undo_token` matches the
+  credential-redaction rule, so the sheet for `calendar_undo_write` would otherwise ask for consent
+  to `undo_token: [REDACTED]`. It now carries a second line: the recorded summary of the write that
+  would be reversed, read from the journal without spending the token, or a plain statement that the
+  token stands for nothing. The line is server-authored and is escaped and bounded exactly like the
+  argument preview.
 - **Mail search has tests that read a Mail store.** The provider with the largest surface in the
   repo, and the thinnest coverage, now runs against a synthetic Envelope Index with the
   `subjects`/`addresses`/`recipients` lookup schema and real `.emlx` files on disk, redirected

--- a/README.md
+++ b/README.md
@@ -297,7 +297,10 @@ What it does not cover, in the order you are likely to hit it:
 - **Only the fields these tools write.** Attendees, attachments, availability, recurrence rules, and
   travel time are outside the write contract and therefore outside the undo contract. An event
   rebuilt after a delete keeps its title, times, all-day flag, location, URL, notes, and relative
-  alarms, and nothing else.
+  alarms, and nothing else. An alarm pinned to an absolute date is not one of those: these tools only
+  ever create relative ones, the snapshot records only relative offsets, and an absolute alarm set in
+  Calendar.app is gone after the rebuild. An event that carries any of this cannot be taken back in
+  full, only rebuilt from the part of it these tools can write.
 - **Tokens live in memory.** They are single-use, expire 30 minutes after the write, are capped at
   the 20 most recent writes, and are gone when the app restarts. Writing them to disk would put a
   second copy of calendar content outside the calendar, which is a worse trade than a short window.
@@ -307,7 +310,12 @@ What it does not cover, in the order you are likely to hit it:
 - **Undo is a write.** It needs the same launch opt-in and its own approval sheet, it can fail
   against a calendar that has since become read-only, and it does not check whether something else
   changed the event in the meantime. It writes the recorded previous values over whatever is there
-  now. When it fails, nothing changes and the token stays valid.
+  now. When it fails, nothing changes and the token stays valid. The sheet reads the token before you
+  answer it, so a sheet left open past the 30-minute window ends in an expired token rather than an
+  undo.
+- **A token is a capability.** It travels in the response of the write it belongs to. Anything that
+  can read that response can spend it, up to the point where the approval sheet asks a human. The
+  journal belongs to the app process, not to a client, so it is shared by every connected client.
 
 The approval sheet for `calendar_undo_write` shows what the token stands for, not the token: its only
 argument matches the credential-redaction rule and would otherwise read `undo_token: [REDACTED]`. The

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Each group is disabled when its variable is absent, empty, malformed, or false. 
 
 | Environment variable | Tools enabled | Additional control |
 |---|---|---|
-| `M3MCP_ENABLE_CALENDAR_MUTATIONS=1` | `calendar_create_event`, `calendar_update_event`, `calendar_delete_event`, `calendar_create_calendar`, `calendar_delete_calendar` | Native approval for every call |
+| `M3MCP_ENABLE_CALENDAR_MUTATIONS=1` | `calendar_create_event`, `calendar_update_event`, `calendar_delete_event`, `calendar_create_calendar`, `calendar_delete_calendar`, `calendar_undo_write` | Native approval for every call that writes |
 | `M3MCP_ENABLE_PERMISSION_UI=1` | `permissions_request`, `permissions_open_settings` | macOS owns the resulting prompt or settings UI |
 | `M3MCP_ENABLE_USER_SHORTCUTS=1` | `ai_writing_tools`, `ai_translate` | Native approval for every call; Shortcut behavior is open-world |
 
@@ -256,15 +256,58 @@ token, and use the bridge path from the table above for the app you actually run
 }
 ```
 
-Enable only the groups you need. Environment opt-in makes tools available; it does not pre-approve Calendar or Shortcut calls. For those calls, the app displays the tool name and a bounded, credential-redacted argument preview. Denial, dismissal, timeout, cancellation, or the absence of a usable app window rejects that one call. Approval is not reusable.
+Enable only the groups you need. Environment opt-in makes tools available; it does not pre-approve Calendar or Shortcut calls. For those calls, the app displays the tool name and a bounded, credential-redacted argument preview. Denial, dismissal, timeout, cancellation, or the absence of a usable app window rejects that one call. Approval is not reusable. A call that carries `dry_run: true` writes nothing and shows no sheet, because there is nothing to consent to; see below.
 
-Cancellation is best-effort, cooperative interruption, not rollback. A client cancellation or disconnect is propagated to in-flight work where the underlying API supports interruption, but an already-raised macOS permission prompt, a running Automation determination, or a running in-process `NSAppleScript` call can remain until the system operation finishes. The caller still returns promptly, and the shared Apple Event slot remains held until that native operation actually ends. A Calendar save/delete or Shortcut action that already happened is not reversed. Read back Calendar state and inspect Shortcut effects before retrying a cancelled call.
+Cancellation is best-effort, cooperative interruption, not rollback. A client cancellation or disconnect is propagated to in-flight work where the underlying API supports interruption, but an already-raised macOS permission prompt, a running Automation determination, or a running in-process `NSAppleScript` call can remain until the system operation finishes. The caller still returns promptly, and the shared Apple Event slot remains held until that native operation actually ends. A Calendar save/delete or Shortcut action that already happened is not reversed by the cancellation. For a single event, `calendar_undo_write` can reverse it afterwards, but only from the token in a response a cancelled caller may never have received. Read back Calendar state and inspect Shortcut effects before retrying a cancelled call.
 
 ### User-created Shortcut contract
 
 The optional `ai_writing_tools` and `ai_translate` tools run Shortcuts named exactly `Writing Tools` and `Translate`. A Shortcut receives a versioned JSON document over standard input and must return non-empty UTF-8 plain text. Standard output and standard error are each limited to 1 MiB, and execution is limited to 60 seconds. A user-created Shortcut can make network requests, modify files, or perform any other action its author added; AppleMCP cannot constrain those actions.
 
 The complete input schemas and setup notes are in [User Shortcut contract](docs/SHORTCUTS.md).
+
+### Dry run, undo, and what neither covers
+
+Two separate questions sit in front of a calendar write. What would this do, and may it happen? The
+approval sheet answers only the second, and answers it about the arguments rather than the effect.
+
+**`dry_run`.** Every calendar write tool takes `dry_run`. With `dry_run: true` the tool resolves the
+calendar, parses the timestamps, applies every validation rule, works out which fields would change,
+reports the result with `meta.dry_run = "true"`, and writes nothing. It shows no approval sheet
+either: nothing is being approved. The launch opt-in still applies, so a preview is only reachable
+where the mutation group was enabled at launch, and it shows nothing the default read tools do not
+already show. Only the literal boolean `true` selects a preview. `"true"`, `1`, and a missing value
+all mean commit, so no existing caller turns into a silent no-op.
+
+**Undo.** A confirmed mistake used to stay. `calendar_create_event`, `calendar_update_event`, and
+`calendar_delete_event` now take a snapshot before they write and return `meta.undo_token` after
+they have. `calendar_undo_write` spends that token: it deletes an event that was created, writes the
+previous values back over the fields an update changed, and rebuilds a deleted event from the
+snapshot taken just before it went. `dry_run: true` on the undo reports the plan and leaves the
+token unspent.
+
+What it does not cover, in the order you are likely to hit it:
+
+- **A rebuilt event has a new id.** EventKit cannot hand an identifier back, so anything holding the
+  old one still points at nothing. `meta.undo_restores_identifier` says so before you act.
+- **Recurring events get no token at all.** Neither does `span: "future_events"`. Deleting one
+  occurrence detaches it from its series, and a single snapshot cannot describe what happens to the
+  occurrences it never saw. The write still happens; the response carries `meta.undo_unavailable`
+  with the reason instead of a token.
+- **Only the fields these tools write.** Attendees, attachments, availability, recurrence rules, and
+  travel time are outside the write contract and therefore outside the undo contract. An event
+  rebuilt after a delete keeps its title, times, all-day flag, location, URL, notes, and relative
+  alarms, and nothing else.
+- **Tokens live in memory.** They are single-use, expire 30 minutes after the write, are capped at
+  the 20 most recent writes, and are gone when the app restarts. Writing them to disk would put a
+  second copy of calendar content outside the calendar, which is a worse trade than a short window.
+- **Calendars are not events.** `calendar_create_calendar` and `calendar_delete_calendar` support
+  `dry_run` but issue no undo token. Deleting a calendar destroys every event in it, and that is
+  what the two matching keys, `id` and `title`, are for.
+- **Undo is a write.** It needs the same launch opt-in and its own approval sheet, it can fail
+  against a calendar that has since become read-only, and it does not check whether something else
+  changed the event in the meantime. It writes the recorded previous values over whatever is there
+  now. When it fails, nothing changes and the token stays valid.
 
 ## Voice Memos and speech privacy
 

--- a/README.md
+++ b/README.md
@@ -310,9 +310,9 @@ What it does not cover, in the order you are likely to hit it:
 - **Undo is a write.** It needs the same launch opt-in and its own approval sheet, it can fail
   against a calendar that has since become read-only, and it does not check whether something else
   changed the event in the meantime. It writes the recorded previous values over whatever is there
-  now. When it fails, nothing changes and the token stays valid. The sheet reads the token before you
-  answer it, so a sheet left open past the 30-minute window ends in an expired token rather than an
-  undo.
+  now. When it fails, nothing changes and the token stays valid. The sheet reads the token before it
+  is answered and the undo spends it afterwards, so a token whose 30 minutes run out between those
+  two moments is reported as expired instead of being quietly spent.
 - **A token is a capability.** It travels in the response of the write it belongs to. Anything that
   can read that response can spend it, up to the point where the approval sheet asks a human. The
   journal belongs to the app process, not to a client, so it is shared by every connected client.

--- a/README.md
+++ b/README.md
@@ -309,6 +309,24 @@ What it does not cover, in the order you are likely to hit it:
   changed the event in the meantime. It writes the recorded previous values over whatever is there
   now. When it fails, nothing changes and the token stays valid.
 
+The approval sheet for `calendar_undo_write` shows what the token stands for, not the token: its only
+argument matches the credential-redaction rule and would otherwise read `undo_token: [REDACTED]`. The
+sheet carries the recorded summary of the write that would be reversed, and says plainly when a token
+resolves to nothing.
+
+The snapshot mapping is covered by ordinary tests against real `EKEvent` objects. The round trip
+through the calendar itself needs Calendar access, which no CI runner has, so it lives in a test that
+skips unless it is asked for twice:
+
+```bash
+M3MCP_CALENDAR_UNDO_LIVE=1 swift test --filter CalendarUndoLiveTests
+```
+
+It also requires full Calendar authorization to be granted already; it reads the status and never
+requests it, so it can never raise a permission panel. It creates its own calendar in the local
+("On My Mac") source, works only inside it, and removes it again. Without a local source it skips
+rather than write into an account that syncs.
+
 ## Voice Memos and speech privacy
 
 Stored transcripts are read directly from a private `tsrp` atom inside each recording. For a fresh transcription, AppleMCP uses `SpeechAnalyzer` on macOS 26 when available and otherwise `SFSpeechRecognizer` with `requiresOnDeviceRecognition = true`.

--- a/Sources/M3MCPApp/Providers/CalendarProvider.swift
+++ b/Sources/M3MCPApp/Providers/CalendarProvider.swift
@@ -16,6 +16,10 @@ final class CalendarProvider {
 
     private let store = EKEventStore()
 
+    /// What the last few committed writes replaced. See `M3MCPCalendarUndoJournal` for why it is in
+    /// memory and why it is bounded.
+    let undoJournal = M3MCPCalendarUndoJournal()
+
     // MARK: - Read
 
     func search(input: [String: JSONValue]) async -> ToolResponse {
@@ -218,6 +222,7 @@ final class CalendarProvider {
     // MARK: - Write: events
 
     func createEvent(input: [String: JSONValue]) async -> ToolResponse {
+        let intent = M3MCPWriteIntent.resolve(from: input)
         switch await access(need: .write) {
         case .denied(let response):
             return response
@@ -313,6 +318,19 @@ final class CalendarProvider {
             event.notes = suppliedNotes
         }
 
+        // Everything above this line resolved the write; nothing below it has happened yet. That is
+        // what makes the preview worth having: it answers which calendar, which times, which slug,
+        // using the same code the commit would use.
+        if intent == .dryRun {
+            return ToolResponse(
+                ok: true,
+                source: "EventKit",
+                items: [dryRunItem(from: item(for: event), id: "dry-run", operation: "create_event")],
+                message: "Dry run: would create '\(title)' in '\(calendar.title)'. Nothing was written.",
+                meta: ["dry_run": "true", "undo_available_after_commit": "true"]
+            )
+        }
+
         guard !Task.isCancelled else {
             return cancelledBeforeWrite("event creation")
         }
@@ -322,17 +340,31 @@ final class CalendarProvider {
             return failure("Could not save the event: \(error.localizedDescription)")
         }
 
+        var meta = ["dry_run": "false"]
+        if let identifier = event.eventIdentifier, !identifier.isEmpty {
+            let record = await undoJournal.record(
+                tool: .calendarCreateEvent,
+                summary: Self.undoSummary("creating '\(title)' in '\(calendar.title)'"),
+                action: .removeCreatedEvent(eventIdentifier: identifier)
+            )
+            meta.merge(Self.undoMeta(for: record)) { current, _ in current }
+        } else {
+            meta["undo_unavailable"] = "EventKit returned no identifier for the created event"
+        }
+
         return ToolResponse(
             ok: true,
             source: "EventKit",
             items: [item(for: event)],
-            message: "Created '\(title)' in '\(calendar.title)'."
+            message: "Created '\(title)' in '\(calendar.title)'.",
+            meta: meta
         )
     }
 
     /// Changes only the fields present in `input`. An absent field is left alone; that is what makes
     /// this safe to call on an event the caller did not create.
     func updateEvent(input: [String: JSONValue]) async -> ToolResponse {
+        let intent = M3MCPWriteIntent.resolve(from: input)
         switch await access(need: .write) {
         case .denied(let response):
             return response
@@ -354,6 +386,11 @@ final class CalendarProvider {
         guard event.calendar.allowsContentModifications else {
             return failure("Event '\(event.title ?? id)' is in read-only calendar '\(event.calendar.title)'.")
         }
+
+        // Taken before the first assignment below, because after it the previous state exists
+        // nowhere else.
+        let before = snapshot(of: event)
+        let undoReason = Self.undoUnavailableReason(event: event, span: recurrenceSpan)
 
         var changed: [String] = []
 
@@ -463,24 +500,76 @@ final class CalendarProvider {
             return failure("Nothing to change. Pass at least one of title, start, end, duration_minutes, all_day, location, url, notes, project_slug, calendar.")
         }
 
+        if intent == .dryRun {
+            // The event object carries the pending values now, which is what makes it a useful
+            // preview. It is dropped back to its saved state immediately afterwards: nothing was
+            // committed, so nothing may be left dirty for the next reader of the same store.
+            let preview = dryRunItem(
+                from: item(for: event),
+                id: id,
+                operation: "update_event",
+                extra: [
+                    "would_change": changed.sorted().joined(separator: ", "),
+                    "span": recurrenceSpan == .futureEvents ? "future_events" : "this_event"
+                ]
+            )
+            event.reset()
+            var meta = [
+                "dry_run": "true",
+                "would_change": changed.sorted().joined(separator: ", ")
+            ]
+            meta["undo_available_after_commit"] = String(undoReason == nil)
+            if let undoReason {
+                meta["undo_unavailable"] = undoReason
+            }
+            return ToolResponse(
+                ok: true,
+                source: "EventKit",
+                items: [preview],
+                message: "Dry run: would update \(changed.sorted().joined(separator: ", ")) on '\(event.title ?? id)'. Nothing was written.",
+                meta: meta
+            )
+        }
+
         guard !Task.isCancelled else {
+            event.reset()
             return cancelledBeforeWrite("event update")
         }
         do {
             try store.save(event, span: recurrenceSpan, commit: true)
         } catch {
+            event.reset()
             return failure("Could not save the event: \(error.localizedDescription)")
+        }
+
+        var meta = ["dry_run": "false"]
+        if let undoReason {
+            meta["undo_unavailable"] = undoReason
+        } else {
+            let record = await undoJournal.record(
+                tool: .calendarUpdateEvent,
+                summary: Self.undoSummary(
+                    "updating \(changed.sorted().joined(separator: ", ")) on '\(event.title ?? id)'"
+                ),
+                action: .restorePreviousValues(
+                    eventIdentifier: id,
+                    previous: Self.previousValues(from: before, changedFieldNames: changed)
+                )
+            )
+            meta.merge(Self.undoMeta(for: record)) { current, _ in current }
         }
 
         return ToolResponse(
             ok: true,
             source: "EventKit",
             items: [item(for: event)],
-            message: "Updated \(changed.joined(separator: ", "))."
+            message: "Updated \(changed.joined(separator: ", ")).",
+            meta: meta
         )
     }
 
     func deleteEvent(input: [String: JSONValue]) async -> ToolResponse {
+        let intent = M3MCPWriteIntent.resolve(from: input)
         switch await access(need: .write) {
         case .denied(let response):
             return response
@@ -505,6 +594,32 @@ final class CalendarProvider {
 
         let title = event.title ?? "(untitled event)"
         let calendarTitle = event.calendar.title
+        // The event is about to stop existing, so this is the last moment it can be read.
+        let before = snapshot(of: event)
+        let undoReason = Self.undoUnavailableReason(event: event, span: recurrenceSpan)
+        let spanName = recurrenceSpan == .futureEvents ? "future_events" : "this_event"
+
+        if intent == .dryRun {
+            var meta = ["dry_run": "true", "span": spanName]
+            meta["undo_available_after_commit"] = String(undoReason == nil)
+            if let undoReason {
+                meta["undo_unavailable"] = undoReason
+            }
+            return ToolResponse(
+                ok: true,
+                source: "EventKit",
+                items: [
+                    dryRunItem(
+                        from: item(for: event),
+                        id: id,
+                        operation: "delete_event",
+                        extra: ["span": spanName]
+                    )
+                ],
+                message: "Dry run: would delete '\(title)' from '\(calendarTitle)'. Nothing was written.",
+                meta: meta
+            )
+        }
 
         guard !Task.isCancelled else {
             return cancelledBeforeWrite("event deletion")
@@ -515,10 +630,23 @@ final class CalendarProvider {
             return failure("Could not delete the event: \(error.localizedDescription)")
         }
 
+        var meta = ["dry_run": "false"]
+        if let undoReason {
+            meta["undo_unavailable"] = undoReason
+        } else {
+            let record = await undoJournal.record(
+                tool: .calendarDeleteEvent,
+                summary: Self.undoSummary("deleting '\(title)' from '\(calendarTitle)'"),
+                action: .recreateDeletedEvent(before)
+            )
+            meta.merge(Self.undoMeta(for: record)) { current, _ in current }
+        }
+
         return ToolResponse(
             ok: true,
             source: "EventKit",
-            message: "Deleted '\(title)' from '\(calendarTitle)'."
+            message: "Deleted '\(title)' from '\(calendarTitle)'.",
+            meta: meta
         )
     }
 
@@ -530,6 +658,7 @@ final class CalendarProvider {
     /// account's other devices and to whoever that account shares with. Anything scratch — a test
     /// calendar above all — belongs on the machine that made it.
     func createCalendar(input: [String: JSONValue]) async -> ToolResponse {
+        let intent = M3MCPWriteIntent.resolve(from: input)
         switch await access(need: .write) {
         case .denied(let response):
             return response
@@ -575,6 +704,31 @@ final class CalendarProvider {
             )
         }
 
+        if intent == .dryRun {
+            return ToolResponse(
+                ok: true,
+                source: "EventKit",
+                items: [
+                    DataItem(
+                        id: "dry-run",
+                        title: title,
+                        subtitle: source.title,
+                        kind: "calendar_write_preview",
+                        source: "EventKit",
+                        preview: nil,
+                        metadata: [
+                            "dry_run": "true",
+                            "operation": "create_calendar",
+                            "source": source.title,
+                            "source_type": describe(source.sourceType)
+                        ]
+                    )
+                ],
+                message: "Dry run: would create calendar '\(title)' in source '\(source.title)'. Nothing was written.",
+                meta: ["dry_run": "true", "source_type": describe(source.sourceType)]
+            )
+        }
+
         let calendar = EKCalendar(for: .event, eventStore: store)
         calendar.title = title
         calendar.source = source
@@ -606,7 +760,13 @@ final class CalendarProvider {
                     ]
                 )
             ],
-            message: "Created calendar '\(title)' in source '\(source.title)'."
+            message: "Created calendar '\(title)' in source '\(source.title)'.",
+            meta: [
+                "dry_run": "false",
+                // calendar_undo_write reverses single events. A calendar is not in its vocabulary,
+                // and saying so here is cheaper than letting a caller assume otherwise.
+                "undo_unavailable": "calendar_undo_write covers events, not calendars"
+            ]
         )
     }
 
@@ -616,6 +776,7 @@ final class CalendarProvider {
     /// with no undo, and an identifier alone is easy to carry over from a stale listing — so the
     /// second key is what proves the caller means *this* calendar.
     func deleteCalendar(input: [String: JSONValue]) async -> ToolResponse {
+        let intent = M3MCPWriteIntent.resolve(from: input)
         switch await access(need: .write) {
         case .denied(let response):
             return response
@@ -638,6 +799,26 @@ final class CalendarProvider {
             return failure("Calendar '\(calendar.title)' is immutable and cannot be deleted.")
         }
 
+        if intent == .dryRun {
+            return ToolResponse(
+                ok: true,
+                source: "EventKit",
+                items: [
+                    calendarItem(
+                        for: calendar,
+                        defaultCalendarID: store.defaultCalendarForNewEvents?.calendarIdentifier
+                    )
+                ],
+                message: "Dry run: would delete calendar '\(calendar.title)' and every event in it. "
+                    + "Nothing was written, and there is no undo for this once it is committed.",
+                meta: [
+                    "dry_run": "true",
+                    "undo_available_after_commit": "false",
+                    "undo_unavailable": "calendar_undo_write covers events, not calendars"
+                ]
+            )
+        }
+
         guard !Task.isCancelled else {
             return cancelledBeforeWrite("calendar deletion")
         }
@@ -647,7 +828,15 @@ final class CalendarProvider {
             return failure("Could not delete calendar '\(title)': \(error.localizedDescription)")
         }
 
-        return ToolResponse(ok: true, source: "EventKit", message: "Deleted calendar '\(title)'.")
+        return ToolResponse(
+            ok: true,
+            source: "EventKit",
+            message: "Deleted calendar '\(title)'.",
+            meta: [
+                "dry_run": "false",
+                "undo_unavailable": "calendar_undo_write covers events, not calendars"
+            ]
+        )
     }
 
     // MARK: - Access
@@ -911,5 +1100,474 @@ final class CalendarProvider {
         case .birthdays: return "birthdays"
         @unknown default: return "unknown"
         }
+    }
+}
+
+/// Snapshot capture, snapshot application, and the tool that spends an undo token.
+///
+/// Kept beside `CalendarProvider` rather than inside it because it is the one part of calendar
+/// writing that has to be readable on its own: what is recorded, what is put back, and what is
+/// admitted to be out of reach.
+extension CalendarProvider {
+    static let maximumUndoSummaryUTF8Bytes = 160
+
+    // MARK: - Capture
+
+    /// Reads the fields these tools can write off a live event, before it changes.
+    func snapshot(of event: EKEvent) -> M3MCPCalendarEventSnapshot {
+        M3MCPCalendarEventSnapshot(
+            title: event.title,
+            isAllDay: event.isAllDay,
+            startDate: event.startDate,
+            endDate: event.endDate,
+            location: event.location,
+            url: event.url?.absoluteString,
+            notes: event.notes,
+            calendarIdentifier: event.calendar?.calendarIdentifier,
+            // An alarm fixed to a wall-clock date is not a relative reminder and is not restored as
+            // one; `alarm_minutes_before` is the only alarm shape these tools create.
+            alarmOffsetsSeconds: (event.alarms ?? [])
+                .filter { $0.absoluteDate == nil }
+                .map(\.relativeOffset)
+        )
+    }
+
+    /// The names `updateEvent` reports back to the caller, mapped onto the fields that carry them.
+    ///
+    /// `notes` and `project_slug` are two ways of writing one field, so both map to `.notes`; the
+    /// snapshot holds the raw notes text, which is what restores either of them.
+    static func undoField(forChangeName name: String) -> M3MCPCalendarField? {
+        switch name {
+        case "title": return .title
+        case "all_day": return .allDay
+        case "start": return .start
+        case "end": return .end
+        case "location": return .location
+        case "url": return .url
+        case "notes", "project_slug": return .notes
+        case "calendar": return .calendar
+        default: return nil
+        }
+    }
+
+    /// Turns the changed field names into the previous values that reverse them.
+    ///
+    /// Toggling `all_day` drags the start and end with it inside EventKit, whether or not the caller
+    /// passed them, so those two are always recorded alongside it. Restoring the flag on its own
+    /// would leave the normalized times in place and call it an undo.
+    static func previousValues(
+        from snapshot: M3MCPCalendarEventSnapshot,
+        changedFieldNames: [String]
+    ) -> [M3MCPCalendarField: M3MCPCalendarPreviousValue] {
+        var fields = Set(changedFieldNames.compactMap(undoField(forChangeName:)))
+        if fields.contains(.allDay) {
+            fields.formUnion([.start, .end])
+        }
+
+        var previous: [M3MCPCalendarField: M3MCPCalendarPreviousValue] = [:]
+        for field in fields {
+            switch field {
+            case .title:
+                previous[field] = snapshot.title.map { .text($0) } ?? .cleared
+            case .allDay:
+                previous[field] = .flag(snapshot.isAllDay)
+            case .start:
+                previous[field] = snapshot.startDate.map { .timestamp($0) } ?? .cleared
+            case .end:
+                previous[field] = snapshot.endDate.map { .timestamp($0) } ?? .cleared
+            case .location:
+                previous[field] = snapshot.location.map { .text($0) } ?? .cleared
+            case .url:
+                previous[field] = snapshot.url.map { .text($0) } ?? .cleared
+            case .notes:
+                previous[field] = snapshot.notes.map { .text($0) } ?? .cleared
+            case .calendar:
+                previous[field] = snapshot.calendarIdentifier.map { .text($0) } ?? .cleared
+            }
+        }
+        return previous
+    }
+
+    /// An undo snapshot is offered only where it can be honoured.
+    ///
+    /// A recurring event is the case it cannot. EventKit does not hand back an occurrence: deleting
+    /// one detaches it from its series, and rebuilding it as a standalone event would look restored
+    /// while the series had moved on without it. `future_events` is worse still, because the write
+    /// touches occurrences the snapshot never saw. Both keep working exactly as before; they simply
+    /// return no token, and say so.
+    static func undoIsRepresentable(event: EKEvent, span: EKSpan) -> Bool {
+        span == .thisEvent && (event.recurrenceRules ?? []).isEmpty
+    }
+
+    static func undoUnavailableReason(event: EKEvent, span: EKSpan) -> String? {
+        if span != .thisEvent {
+            return "no undo snapshot: span 'future_events' changes occurrences a single snapshot cannot describe"
+        }
+        if !(event.recurrenceRules ?? []).isEmpty {
+            return "no undo snapshot: the event is part of a recurring series"
+        }
+        return nil
+    }
+
+    static func undoSummary(_ text: String) -> String {
+        ProviderOutputBudget.text(text, maximumUTF8Bytes: maximumUndoSummaryUTF8Bytes).text
+    }
+
+    /// The response-level facts a caller needs to act on an undo token without reading prose.
+    static func undoMeta(for record: M3MCPCalendarUndoRecord) -> [String: String] {
+        let formatter = ISO8601DateFormatter()
+        return [
+            "undo_token": record.token,
+            "undo_expires_at": formatter.string(from: record.expiresAt),
+            "undo_restores_identifier": String(record.restoresIdentifier),
+            "undo_tool": M3MCPToolName.calendarUndoWrite.rawValue
+        ]
+    }
+
+    // MARK: - Preview
+
+    /// Re-labels a resolved event as the change that has not happened.
+    ///
+    /// The kind is deliberately not `calendar_event`: a client that stores results should not file a
+    /// preview next to things that exist.
+    func dryRunItem(
+        from item: DataItem,
+        id: String,
+        operation: String,
+        extra: [String: String] = [:]
+    ) -> DataItem {
+        var metadata = item.metadata
+        metadata["dry_run"] = "true"
+        metadata["operation"] = operation
+        for (key, value) in extra {
+            metadata[key] = value
+        }
+        return DataItem(
+            id: id,
+            title: item.title,
+            subtitle: item.subtitle,
+            kind: "calendar_write_preview",
+            source: "EventKit",
+            preview: item.preview,
+            metadata: metadata
+        )
+    }
+
+    // MARK: - Application
+
+    /// A refusal with a caller-facing reason. `Result` needs an `Error`, and the reason is the whole
+    /// payload, so this is the smallest honest way to carry it.
+    struct UndoProblem: Error, Equatable {
+        let message: String
+    }
+
+    enum UndoOutcome {
+        case restored([DataItem], String)
+        case nothingToDo(String)
+        case failed(String)
+    }
+
+    /// Writes recorded previous values back over an event.
+    ///
+    /// Ordering matches `updateEvent`: the all-day flag first, because it decides how the timestamps
+    /// are interpreted, then the rest.
+    func applyPreviousValues(
+        _ previous: [M3MCPCalendarField: M3MCPCalendarPreviousValue],
+        to event: EKEvent
+    ) -> Result<[String], UndoProblem> {
+        var restored: [String] = []
+
+        if case .flag(let wasAllDay)? = previous[.allDay] {
+            event.isAllDay = wasAllDay
+            restored.append("all_day")
+        }
+        if let value = previous[.start] {
+            guard case .timestamp(let date) = value else {
+                return .failure(UndoProblem(message: "The recorded previous start is not a timestamp."))
+            }
+            event.startDate = date
+            restored.append("start")
+        }
+        if let value = previous[.end] {
+            guard case .timestamp(let date) = value else {
+                return .failure(UndoProblem(message: "The recorded previous end is not a timestamp."))
+            }
+            event.endDate = date
+            restored.append("end")
+        }
+        if let value = previous[.title] {
+            // A blank title is not a state EventKit keeps, so a create-then-undo cannot produce one.
+            event.title = text(of: value) ?? ""
+            restored.append("title")
+        }
+        if let value = previous[.location] {
+            event.location = text(of: value)
+            restored.append("location")
+        }
+        if let value = previous[.url] {
+            if let raw = text(of: value) {
+                guard let url = URL(string: raw) else {
+                    return .failure(UndoProblem(message: "The recorded previous url is no longer a valid URL."))
+                }
+                event.url = url
+            } else {
+                event.url = nil
+            }
+            restored.append("url")
+        }
+        if let value = previous[.notes] {
+            event.notes = text(of: value)
+            restored.append("notes")
+        }
+        if let value = previous[.calendar] {
+            guard let identifier = text(of: value),
+                  let calendar = store.calendar(withIdentifier: identifier) else {
+                return .failure(UndoProblem(message: "The calendar the event came from no longer exists, so it cannot be moved back."))
+            }
+            guard calendar.allowsContentModifications else {
+                return .failure(UndoProblem(message: "Calendar '\(calendar.title)' is read-only, so the event cannot be moved back into it."))
+            }
+            event.calendar = calendar
+            restored.append("calendar")
+        }
+
+        guard CalendarEventTiming.isValid(start: event.startDate, end: event.endDate) else {
+            return .failure(UndoProblem(message: "Restoring the previous values would leave 'end' at or before 'start'."))
+        }
+        return .success(restored.sorted())
+    }
+
+    /// Builds a deleted event again from its snapshot.
+    func rebuild(from snapshot: M3MCPCalendarEventSnapshot) -> Result<EKEvent, UndoProblem> {
+        guard let identifier = snapshot.calendarIdentifier,
+              let calendar = store.calendar(withIdentifier: identifier) else {
+            return .failure(UndoProblem(message: "The calendar the event was deleted from no longer exists, so it cannot be put back."))
+        }
+        guard calendar.allowsContentModifications else {
+            return .failure(UndoProblem(message: "Calendar '\(calendar.title)' is read-only, so the event cannot be put back into it."))
+        }
+        guard let start = snapshot.startDate, let end = snapshot.endDate else {
+            return .failure(UndoProblem(message: "The snapshot has no start or end, so the event cannot be rebuilt."))
+        }
+
+        let event = EKEvent(eventStore: store)
+        event.calendar = calendar
+        event.title = snapshot.title ?? ""
+        event.isAllDay = snapshot.isAllDay
+        event.startDate = start
+        event.endDate = end
+        event.location = snapshot.location
+        event.notes = snapshot.notes
+        if let raw = snapshot.url {
+            event.url = URL(string: raw)
+        }
+        for offset in snapshot.alarmOffsetsSeconds {
+            event.addAlarm(EKAlarm(relativeOffset: offset))
+        }
+        return .success(event)
+    }
+
+    private func text(of value: M3MCPCalendarPreviousValue) -> String? {
+        if case .text(let string) = value { return string }
+        return nil
+    }
+
+    // MARK: - Tool
+
+    /// Spends one undo token.
+    func undoWrite(input: [String: JSONValue]) async -> ToolResponse {
+        switch await access(need: .write) {
+        case .denied(let response):
+            return response
+        case .granted:
+            break
+        }
+
+        let token = input.string("undo_token").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else {
+            return failure("'undo_token' is required and must not be blank.")
+        }
+        let intent = M3MCPWriteIntent.resolve(from: input)
+
+        // A preview must not spend the token it is previewing: reading the plan is not carrying it
+        // out, and losing the chance to undo by asking about it would be the worst of both.
+        let lookup = intent == .dryRun
+            ? await undoJournal.peek(token: token)
+            : await undoJournal.consume(token: token)
+
+        let record: M3MCPCalendarUndoRecord
+        switch lookup {
+        case .found(let found):
+            record = found
+        case .alreadyUndone:
+            return failure("That undo token has already been spent. Each write can be undone once.")
+        case .expired:
+            let minutes = Int(M3MCPCalendarUndoJournal.defaultLifetime / 60)
+            return failure("That undo token has expired. Undo snapshots are kept for \(minutes) minutes after the write.")
+        case .unknown:
+            return failure(
+                "No undo snapshot for that token. Tokens are held in memory only, are spent once, "
+                + "and are dropped when the AppleMCP app restarts."
+            )
+        }
+
+        if intent == .dryRun {
+            return ToolResponse(
+                ok: true,
+                source: "EventKit",
+                items: [undoPlanItem(for: record, dryRun: true)],
+                message: "Dry run: would reverse \(record.summary). Nothing was written, and the token is still unspent.",
+                meta: undoMeta(for: record, intent: .dryRun, applied: false)
+            )
+        }
+
+        guard !Task.isCancelled else {
+            await undoJournal.reinstate(record)
+            return cancelledBeforeWrite("undo")
+        }
+
+        let outcome = apply(record)
+        switch outcome {
+        case .restored(let items, let message):
+            return ToolResponse(
+                ok: true,
+                source: "EventKit",
+                items: items,
+                message: message,
+                meta: undoMeta(for: record, intent: .commit, applied: true)
+            )
+        case .nothingToDo(let message):
+            return ToolResponse(
+                ok: true,
+                source: "EventKit",
+                message: message,
+                meta: undoMeta(for: record, intent: .commit, applied: false)
+            )
+        case .failed(let message):
+            // The state did not change, so the token has to survive the attempt.
+            await undoJournal.reinstate(record)
+            return failure(message + " The undo token is still valid.")
+        }
+    }
+
+    private func apply(_ record: M3MCPCalendarUndoRecord) -> UndoOutcome {
+        switch record.action {
+        case .removeCreatedEvent(let identifier):
+            guard let event = store.event(withIdentifier: identifier) else {
+                return .nothingToDo("Nothing to undo: the event created by that call no longer exists.")
+            }
+            guard event.calendar.allowsContentModifications else {
+                return .failed("Event '\(event.title ?? identifier)' now sits in read-only calendar '\(event.calendar.title)'.")
+            }
+            let removed = item(for: event)
+            do {
+                try store.remove(event, span: .thisEvent, commit: true)
+            } catch {
+                return .failed("Could not remove the created event: \(error.localizedDescription)")
+            }
+            return .restored([removed], "Undone: removed the event created by \(record.summary).")
+
+        case .restorePreviousValues(let identifier, let previous):
+            guard let event = store.event(withIdentifier: identifier) else {
+                return .failed("The updated event no longer exists, so its previous values cannot be written back.")
+            }
+            guard event.calendar.allowsContentModifications else {
+                return .failed("Event '\(event.title ?? identifier)' is in read-only calendar '\(event.calendar.title)'.")
+            }
+            let restored: [String]
+            switch applyPreviousValues(previous, to: event) {
+            case .success(let fields):
+                restored = fields
+            case .failure(let problem):
+                event.reset()
+                return .failed(problem.message)
+            }
+            do {
+                try store.save(event, span: .thisEvent, commit: true)
+            } catch {
+                event.reset()
+                return .failed("Could not write the previous values back: \(error.localizedDescription)")
+            }
+            return .restored(
+                [item(for: event)],
+                "Undone: restored \(restored.joined(separator: ", ")) on '\(event.title ?? identifier)'."
+            )
+
+        case .recreateDeletedEvent(let snapshot):
+            let event: EKEvent
+            switch rebuild(from: snapshot) {
+            case .success(let rebuilt):
+                event = rebuilt
+            case .failure(let problem):
+                return .failed(problem.message)
+            }
+            do {
+                try store.save(event, span: .thisEvent, commit: true)
+            } catch {
+                return .failed("Could not put the deleted event back: \(error.localizedDescription)")
+            }
+            return .restored(
+                [item(for: event)],
+                "Undone: put '\(event.title ?? "(untitled event)")' back into '\(event.calendar.title)'. "
+                    + "It has a new id, because a deleted event cannot be given its old one."
+            )
+        }
+    }
+
+    private func undoPlanItem(for record: M3MCPCalendarUndoRecord, dryRun: Bool) -> DataItem {
+        let action: String
+        let target: String
+        switch record.action {
+        case .removeCreatedEvent(let identifier):
+            action = "remove_created_event"
+            target = identifier
+        case .restorePreviousValues(let identifier, let previous):
+            action = "restore_previous_values"
+            target = identifier
+            return DataItem(
+                id: identifier,
+                title: record.summary,
+                subtitle: record.tool.rawValue,
+                kind: "calendar_undo_plan",
+                source: "EventKit",
+                preview: previous.keys.map(\.rawValue).sorted().joined(separator: ", "),
+                metadata: [
+                    "undo_action": action,
+                    "event_id": target,
+                    "restores_identifier": String(record.restoresIdentifier),
+                    "dry_run": String(dryRun)
+                ]
+            )
+        case .recreateDeletedEvent(let snapshot):
+            action = "recreate_deleted_event"
+            target = snapshot.title ?? "(untitled event)"
+        }
+        return DataItem(
+            id: target,
+            title: record.summary,
+            subtitle: record.tool.rawValue,
+            kind: "calendar_undo_plan",
+            source: "EventKit",
+            preview: nil,
+            metadata: [
+                "undo_action": action,
+                "restores_identifier": String(record.restoresIdentifier),
+                "dry_run": String(dryRun)
+            ]
+        )
+    }
+
+    private func undoMeta(
+        for record: M3MCPCalendarUndoRecord,
+        intent: M3MCPWriteIntent,
+        applied: Bool
+    ) -> [String: String] {
+        [
+            "dry_run": intent.metaValue,
+            "undo_applied": String(applied),
+            "undone_tool": record.tool.rawValue,
+            "undo_restores_identifier": String(record.restoresIdentifier),
+            "undo_token_spent": String(intent == .commit)
+        ]
     }
 }

--- a/Sources/M3MCPApp/Providers/CalendarProvider.swift
+++ b/Sources/M3MCPApp/Providers/CalendarProvider.swift
@@ -387,6 +387,12 @@ final class CalendarProvider {
             return failure("Event '\(event.title ?? id)' is in read-only calendar '\(event.calendar.title)'.")
         }
 
+        // EventKit can hand back the same instance to two calls. An earlier call that mutated it and
+        // then failed validation would otherwise leave those unsaved values here, and the snapshot
+        // would record a state the calendar never held. Dropping to the last saved state costs
+        // nothing on a clean instance.
+        event.reset()
+
         // Taken before the first assignment below, because after it the previous state exists
         // nowhere else.
         let before = snapshot(of: event)
@@ -397,7 +403,7 @@ final class CalendarProvider {
         if let title = input["title"]?.stringValue {
             let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else {
-                return failure("'title' must not be blank.")
+                return rejectUpdate(event, "'title' must not be blank.")
             }
             event.title = trimmed
             changed.append("title")
@@ -411,7 +417,7 @@ final class CalendarProvider {
 
         if let raw = input["start"]?.stringValue {
             guard let start = date(from: raw, allDay: event.isAllDay) else {
-                return failure("'start' is not an ISO 8601 timestamp: \(raw)")
+                return rejectUpdate(event, "'start' is not an ISO 8601 timestamp: \(raw)")
             }
             event.startDate = start
             changed.append("start")
@@ -419,20 +425,20 @@ final class CalendarProvider {
 
         if let raw = input["end"]?.stringValue {
             guard let end = date(from: raw, allDay: event.isAllDay) else {
-                return failure("'end' is not an ISO 8601 timestamp: \(raw)")
+                return rejectUpdate(event, "'end' is not an ISO 8601 timestamp: \(raw)")
             }
             event.endDate = end
             changed.append("end")
         } else if let minutes = input["duration_minutes"]?.intValue {
             guard (1...525_600).contains(minutes) else {
-                return failure("'duration_minutes' must be between 1 and 525600.")
+                return rejectUpdate(event, "'duration_minutes' must be between 1 and 525600.")
             }
             event.endDate = event.startDate.addingTimeInterval(TimeInterval(minutes) * 60)
             changed.append("end")
         }
 
         guard CalendarEventTiming.isValid(start: event.startDate, end: event.endDate) else {
-            return failure("The resulting 'end' must be after 'start'.")
+            return rejectUpdate(event, "The resulting 'end' must be after 'start'.")
         }
 
         if let location = input["location"]?.stringValue {
@@ -445,7 +451,7 @@ final class CalendarProvider {
                 event.url = nil
             } else {
                 guard let url = URL(string: urlString) else {
-                    return failure("'url' is not a valid URL: \(urlString)")
+                    return rejectUpdate(event, "'url' is not a valid URL: \(urlString)")
                 }
                 event.url = url
             }
@@ -465,7 +471,7 @@ final class CalendarProvider {
                     event.notes = (body?.isEmpty ?? true) ? nil : body
                 } else {
                     guard let notes = CalendarProjectSlug.embed(slug: slugGiven, in: body) else {
-                        return failure(invalidSlugMessage(slugGiven))
+                        return rejectUpdate(event, invalidSlugMessage(slugGiven))
                     }
                     event.notes = notes
                 }
@@ -485,19 +491,19 @@ final class CalendarProvider {
             case .found(let resolved):
                 target = resolved
             case .notFound:
-                return failure("No calendar matches '\(named)'. Use calendar_list_calendars to see the available ones.")
+                return rejectUpdate(event, "No calendar matches '\(named)'. Use calendar_list_calendars to see the available ones.")
             case .ambiguous:
-                return failure("More than one calendar is titled '\(named)'. Pass the exact calendar_id from calendar_list_calendars.")
+                return rejectUpdate(event, "More than one calendar is titled '\(named)'. Pass the exact calendar_id from calendar_list_calendars.")
             }
             guard target.allowsContentModifications else {
-                return failure("Calendar '\(target.title)' is read-only.")
+                return rejectUpdate(event, "Calendar '\(target.title)' is read-only.")
             }
             event.calendar = target
             changed.append("calendar")
         }
 
         guard !changed.isEmpty else {
-            return failure("Nothing to change. Pass at least one of title, start, end, duration_minutes, all_day, location, url, notes, project_slug, calendar.")
+            return rejectUpdate(event, "Nothing to change. Pass at least one of title, start, end, duration_minutes, all_day, location, url, notes, project_slug, calendar.")
         }
 
         if intent == .dryRun {
@@ -538,21 +544,23 @@ final class CalendarProvider {
         do {
             try store.save(event, span: recurrenceSpan, commit: true)
         } catch {
-            event.reset()
-            return failure("Could not save the event: \(error.localizedDescription)")
+            return rejectUpdate(event, "Could not save the event: \(error.localizedDescription)")
         }
 
         var meta = ["dry_run": "false"]
         if let undoReason {
             meta["undo_unavailable"] = undoReason
         } else {
+            // Read after the save, not before: moving an event between accounts can give it a new
+            // identifier, and the undo has to address the event that now exists.
+            let savedIdentifier = event.eventIdentifier ?? id
             let record = await undoJournal.record(
                 tool: .calendarUpdateEvent,
                 summary: Self.undoSummary(
                     "updating \(changed.sorted().joined(separator: ", ")) on '\(event.title ?? id)'"
                 ),
                 action: .restorePreviousValues(
-                    eventIdentifier: id,
+                    eventIdentifier: savedIdentifier,
                     previous: Self.previousValues(from: before, changedFieldNames: changed)
                 )
             )
@@ -591,6 +599,10 @@ final class CalendarProvider {
         guard event.calendar.allowsContentModifications else {
             return failure("Event '\(event.title ?? id)' is in read-only calendar '\(event.calendar.title)'.")
         }
+
+        // Same reason as in updateEvent: a shared instance left dirty by an earlier failed call must
+        // not be mistaken for what the calendar holds.
+        event.reset()
 
         let title = event.title ?? "(untitled event)"
         let calendarTitle = event.calendar.title
@@ -894,6 +906,16 @@ final class CalendarProvider {
             1,
             min(input.int("max_candidates", default: defaultSearchCandidates), maximumSearchCandidates)
         )
+    }
+
+    /// Rejects an update and drops the values already assigned to the shared event instance.
+    ///
+    /// Without this, a call that failed halfway would leave the in-memory event holding values the
+    /// calendar never accepted, and the next call to reach the same instance would read them as the
+    /// state to snapshot.
+    private func rejectUpdate(_ event: EKEvent, _ message: String) -> ToolResponse {
+        event.reset()
+        return failure(message)
     }
 
     private func cancelledBeforeWrite(_ operation: String) -> ToolResponse {
@@ -1339,15 +1361,18 @@ extension CalendarProvider {
 
     /// Builds a deleted event again from its snapshot.
     func rebuild(from snapshot: M3MCPCalendarEventSnapshot) -> Result<EKEvent, UndoProblem> {
+        // The snapshot is checked before the calendar is looked up: a record that cannot describe an
+        // event is a different problem from a calendar that has gone, and the caller can act on
+        // neither if they are reported as one.
+        guard let start = snapshot.startDate, let end = snapshot.endDate else {
+            return .failure(UndoProblem(message: "The snapshot has no start or end, so the event cannot be rebuilt."))
+        }
         guard let identifier = snapshot.calendarIdentifier,
               let calendar = store.calendar(withIdentifier: identifier) else {
             return .failure(UndoProblem(message: "The calendar the event was deleted from no longer exists, so it cannot be put back."))
         }
         guard calendar.allowsContentModifications else {
             return .failure(UndoProblem(message: "Calendar '\(calendar.title)' is read-only, so the event cannot be put back into it."))
-        }
-        guard let start = snapshot.startDate, let end = snapshot.endDate else {
-            return .failure(UndoProblem(message: "The snapshot has no start or end, so the event cannot be rebuilt."))
         }
 
         let event = EKEvent(eventStore: store)
@@ -1373,6 +1398,30 @@ extension CalendarProvider {
     }
 
     // MARK: - Tool
+
+    /// The line the approval sheet shows instead of a redacted token.
+    ///
+    /// Reads the journal without spending the token, and says plainly when the token resolves to
+    /// nothing, so that a sheet is never approved on the assumption that something will be reversed.
+    func undoEffectDescription(input: [String: JSONValue]) async -> String? {
+        let token = input.string("undo_token").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else { return nil }
+        if M3MCPWriteIntent.resolve(from: input) == .dryRun { return nil }
+
+        switch await undoJournal.peek(token: token) {
+        case .found(let record):
+            let identifier = record.restoresIdentifier
+                ? ""
+                : " The event gets a new id."
+            return "Reverses \(record.summary).\(identifier)"
+        case .alreadyUndone:
+            return "This token has already been spent. Nothing would be reversed."
+        case .expired:
+            return "This token has expired. Nothing would be reversed."
+        case .unknown:
+            return "No snapshot matches this token. Nothing would be reversed."
+        }
+    }
 
     /// Spends one undo token.
     func undoWrite(input: [String: JSONValue]) async -> ToolResponse {

--- a/Sources/M3MCPApp/Services/LocalMCPService.swift
+++ b/Sources/M3MCPApp/Services/LocalMCPService.swift
@@ -93,7 +93,7 @@ final class LocalMCPService {
             return cancellationResponse(tool: tool)
         }
 
-        if M3MCPInteractiveApproval.requiresApproval(for: toolName) {
+        if M3MCPInteractiveApproval.requiresApproval(for: toolName, input: input) {
             guard let approvalHandler else {
                 return ToolResponse(
                     ok: false,
@@ -164,6 +164,8 @@ final class LocalMCPService {
             response = await calendarProvider.createCalendar(input: input)
         case .calendarDeleteCalendar:
             response = await calendarProvider.deleteCalendar(input: input)
+        case .calendarUndoWrite:
+            response = await calendarProvider.undoWrite(input: input)
         case .contactsSearch:
             response = await contactsProvider.search(input: input)
         case .mailSearch:

--- a/Sources/M3MCPApp/Services/LocalMCPService.swift
+++ b/Sources/M3MCPApp/Services/LocalMCPService.swift
@@ -102,7 +102,21 @@ final class LocalMCPService {
                 )
             }
 
-            let request = M3MCPToolApprovalRequest(tool: toolName, input: input)
+            // An undo call carries a token and nothing else, and "token" is a redacted key, so the
+            // sheet would ask for consent to a string of asterisks. The journal knows what the token
+            // stands for; peeking it does not spend it.
+            let effect: String?
+            if toolName == .calendarUndoWrite {
+                effect = await calendarProvider.undoEffectDescription(input: input)
+            } else {
+                effect = nil
+            }
+
+            let request = M3MCPToolApprovalRequest(
+                tool: toolName,
+                input: input,
+                effectPreview: effect
+            )
             let approved = await approvalHandler(request)
             // Cancellation wins over an approval result. In particular, a late click cannot start a
             // mutation after the requesting bridge has disconnected.

--- a/Sources/M3MCPApp/Support/NativeToolApprovalCoordinator.swift
+++ b/Sources/M3MCPApp/Support/NativeToolApprovalCoordinator.swift
@@ -136,6 +136,7 @@ final class NativeToolApprovalCoordinator {
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = "Approve one call to \(request.tool.rawValue)?"
+        let effect = request.effectPreview.map { "\n\nEffect\n\($0)" } ?? ""
         alert.informativeText = """
         A local MCP client requested this operation.
 
@@ -143,7 +144,7 @@ final class NativeToolApprovalCoordinator {
         \(request.tool.rawValue)
 
         Arguments
-        \(request.argumentPreview)
+        \(request.argumentPreview)\(effect)
 
         Allow applies to this call only. Deny is the default.
         """

--- a/Sources/M3MCPBridge/ToolCatalog.swift
+++ b/Sources/M3MCPBridge/ToolCatalog.swift
@@ -191,7 +191,7 @@ enum ToolCatalog {
         ),
         MCPTool(
             name: .calendarCreateEvent,
-            description: "Create an event in an explicitly selected macOS calendar via EventKit. Writes to the user's real calendar — use calendar_id from calendar_list_calendars when possible, and confirm the target and times before calling. Pass dry_run to see the resolved calendar and times without writing. A committed create returns metadata.undo_token, which calendar_undo_write spends to delete the event again.",
+            description: "Create an event in an explicitly selected macOS calendar via EventKit. Writes to the user's real calendar — use calendar_id from calendar_list_calendars when possible, and confirm the target and times before calling. Pass dry_run to see the resolved calendar and times without writing. A committed create returns meta.undo_token, which calendar_undo_write spends to delete the event again.",
             schema: objectSchema(properties: [
                 "title": ["type": "string", "description": "Event title."],
                 "start": [
@@ -216,7 +216,7 @@ enum ToolCatalog {
         ),
         MCPTool(
             name: .calendarUpdateEvent,
-            description: "Change an existing macOS Calendar event. Only the fields passed are changed; anything omitted is left as it is. Pass dry_run to see which fields would change, and to what, without writing. A committed change to a non-recurring event returns metadata.undo_token, which calendar_undo_write spends to put the previous values back.",
+            description: "Change an existing macOS Calendar event. Only the fields passed are changed; anything omitted is left as it is. Pass dry_run to see which fields would change, and to what, without writing. A committed change to a non-recurring event returns meta.undo_token, which calendar_undo_write spends to put the previous values back.",
             schema: objectSchema(properties: [
                 "id": ["type": "string", "description": "Event id, from calendar_search or calendar_create_event."],
                 "title": ["type": "string", "description": "New title."],
@@ -239,7 +239,7 @@ enum ToolCatalog {
         ),
         MCPTool(
             name: .calendarDeleteEvent,
-            description: "Delete a macOS Calendar event by id. Pass dry_run to see exactly which event would go, without deleting it. Deleting a non-recurring event with the default span returns metadata.undo_token: calendar_undo_write rebuilds the event from a snapshot taken before the delete, with a new id. There is no undo token for a recurring event or for span=future_events, and none at all after the app restarts.",
+            description: "Delete a macOS Calendar event by id. Pass dry_run to see exactly which event would go, without deleting it. Deleting a non-recurring event with the default span returns meta.undo_token: calendar_undo_write rebuilds the event from a snapshot taken before the delete, with a new id. There is no undo token for a recurring event or for span=future_events, and none at all after the app restarts.",
             schema: objectSchema(properties: [
                 "id": ["type": "string", "description": "Event id, from calendar_search or calendar_create_event."],
                 "span": [
@@ -271,7 +271,7 @@ enum ToolCatalog {
             name: .calendarUndoWrite,
             description: "Reverse one committed calendar_create_event, calendar_update_event, or calendar_delete_event, using the undo_token that write returned. A create is reversed by deleting the event, an update by writing the previous values of the changed fields back, a delete by rebuilding the event from the snapshot taken before it. Tokens are single-use, expire after 30 minutes, and are held in memory only, so they do not survive a restart of the AppleMCP app. Rebuilding a deleted event gives it a new id, and restores only the fields these tools can write.",
             schema: objectSchema(properties: [
-                "undo_token": ["type": "string", "description": "The token from metadata.undo_token of the write to reverse."],
+                "undo_token": ["type": "string", "description": "The token from meta.undo_token of the write to reverse."],
                 "dry_run": ["type": "boolean", "description": "When true, report what the undo would do and leave the token unspent. Default false."]
             ], required: ["undo_token"])
         ),

--- a/Sources/M3MCPBridge/ToolCatalog.swift
+++ b/Sources/M3MCPBridge/ToolCatalog.swift
@@ -260,7 +260,7 @@ enum ToolCatalog {
         ),
         MCPTool(
             name: .calendarDeleteCalendar,
-            description: "Delete a calendar and every event in it. There is no undo for this one, because calendar_undo_write covers single events and not a calendar with its contents, so id and title must both be given and must refer to the same calendar. Pass dry_run to see which calendar the pair resolves to, and how many events it holds, without deleting anything.",
+            description: "Delete a calendar and every event in it. There is no undo for this one, because calendar_undo_write covers single events and not a calendar with its contents, so id and title must both be given and must refer to the same calendar. Pass dry_run to see which calendar the pair resolves to, without deleting anything.",
             schema: objectSchema(properties: [
                 "id": ["type": "string", "description": "Calendar id, from calendar_list_calendars."],
                 "title": ["type": "string", "description": "Exact current title of that calendar. The delete is refused if it does not match."],

--- a/Sources/M3MCPBridge/ToolCatalog.swift
+++ b/Sources/M3MCPBridge/ToolCatalog.swift
@@ -191,7 +191,7 @@ enum ToolCatalog {
         ),
         MCPTool(
             name: .calendarCreateEvent,
-            description: "Create an event in an explicitly selected macOS calendar via EventKit. Writes to the user's real calendar — use calendar_id from calendar_list_calendars when possible, and confirm the target and times before calling.",
+            description: "Create an event in an explicitly selected macOS calendar via EventKit. Writes to the user's real calendar — use calendar_id from calendar_list_calendars when possible, and confirm the target and times before calling. Pass dry_run to see the resolved calendar and times without writing. A committed create returns metadata.undo_token, which calendar_undo_write spends to delete the event again.",
             schema: objectSchema(properties: [
                 "title": ["type": "string", "description": "Event title."],
                 "start": [
@@ -210,12 +210,13 @@ enum ToolCatalog {
                     "type": "string",
                     "description": "Machine-readable project identifier, stored as a 'Project: <slug>' line at the top of the notes and reported back as metadata.project_slug. Lowercase; a-z, 0-9, '-', '_', '.'; max 64 characters. Notes are plain text on every calendar backend, which is why the slug goes there rather than in url."
                 ],
-                "alarm_minutes_before": ["type": "integer", "description": "Add an alarm this many minutes before the start."]
+                "alarm_minutes_before": ["type": "integer", "description": "Add an alarm this many minutes before the start."],
+                "dry_run": ["type": "boolean", "description": "When true, resolve and validate everything, report the exact change that would be made, and write nothing. No approval sheet appears, because nothing is being approved. Default false."]
             ], required: ["title", "start"], anyOfRequired: [["calendar_id"], ["calendar"]])
         ),
         MCPTool(
             name: .calendarUpdateEvent,
-            description: "Change an existing macOS Calendar event. Only the fields passed are changed; anything omitted is left as it is.",
+            description: "Change an existing macOS Calendar event. Only the fields passed are changed; anything omitted is left as it is. Pass dry_run to see which fields would change, and to what, without writing. A committed change to a non-recurring event returns metadata.undo_token, which calendar_undo_write spends to put the previous values back.",
             schema: objectSchema(properties: [
                 "id": ["type": "string", "description": "Event id, from calendar_search or calendar_create_event."],
                 "title": ["type": "string", "description": "New title."],
@@ -232,18 +233,20 @@ enum ToolCatalog {
                 "span": [
                     "type": "string",
                     "description": "For a recurring event: 'this_event' (default) changes this occurrence, 'future_events' changes this one and all later ones."
-                ]
+                ],
+                "dry_run": ["type": "boolean", "description": "When true, resolve and validate everything, report the exact change that would be made, and write nothing. No approval sheet appears, because nothing is being approved. Default false."]
             ], required: ["id"])
         ),
         MCPTool(
             name: .calendarDeleteEvent,
-            description: "Delete a macOS Calendar event by id. There is no undo.",
+            description: "Delete a macOS Calendar event by id. Pass dry_run to see exactly which event would go, without deleting it. Deleting a non-recurring event with the default span returns metadata.undo_token: calendar_undo_write rebuilds the event from a snapshot taken before the delete, with a new id. There is no undo token for a recurring event or for span=future_events, and none at all after the app restarts.",
             schema: objectSchema(properties: [
                 "id": ["type": "string", "description": "Event id, from calendar_search or calendar_create_event."],
                 "span": [
                     "type": "string",
                     "description": "For a recurring event: 'this_event' (default) deletes this occurrence, 'future_events' deletes this one and all later ones."
-                ]
+                ],
+                "dry_run": ["type": "boolean", "description": "When true, resolve and validate everything, report the exact change that would be made, and write nothing. No approval sheet appears, because nothing is being approved. Default false."]
             ], required: ["id"])
         ),
         MCPTool(
@@ -251,16 +254,26 @@ enum ToolCatalog {
             description: "Create a calendar. Defaults to the on-device 'Local' source so a scratch or test calendar does not sync to an account.",
             schema: objectSchema(properties: [
                 "title": ["type": "string", "description": "Calendar title. Must not already exist."],
-                "source": ["type": "string", "description": "Source title to create it in, e.g. 'On My Mac' or an account name. Defaults to the local source."]
+                "source": ["type": "string", "description": "Source title to create it in, e.g. 'On My Mac' or an account name. Defaults to the local source."],
+                "dry_run": ["type": "boolean", "description": "When true, resolve and validate everything, report the exact change that would be made, and write nothing. No approval sheet appears, because nothing is being approved. Default false."]
             ], required: ["title"])
         ),
         MCPTool(
             name: .calendarDeleteCalendar,
-            description: "Delete a calendar and every event in it. There is no undo, so id and title must both be given and must refer to the same calendar.",
+            description: "Delete a calendar and every event in it. There is no undo for this one, because calendar_undo_write covers single events and not a calendar with its contents, so id and title must both be given and must refer to the same calendar. Pass dry_run to see which calendar the pair resolves to, and how many events it holds, without deleting anything.",
             schema: objectSchema(properties: [
                 "id": ["type": "string", "description": "Calendar id, from calendar_list_calendars."],
-                "title": ["type": "string", "description": "Exact current title of that calendar. The delete is refused if it does not match."]
+                "title": ["type": "string", "description": "Exact current title of that calendar. The delete is refused if it does not match."],
+                "dry_run": ["type": "boolean", "description": "When true, resolve and validate everything, report the exact change that would be made, and write nothing. No approval sheet appears, because nothing is being approved. Default false."]
             ], required: ["id", "title"])
+        ),
+        MCPTool(
+            name: .calendarUndoWrite,
+            description: "Reverse one committed calendar_create_event, calendar_update_event, or calendar_delete_event, using the undo_token that write returned. A create is reversed by deleting the event, an update by writing the previous values of the changed fields back, a delete by rebuilding the event from the snapshot taken before it. Tokens are single-use, expire after 30 minutes, and are held in memory only, so they do not survive a restart of the AppleMCP app. Rebuilding a deleted event gives it a new id, and restores only the fields these tools can write.",
+            schema: objectSchema(properties: [
+                "undo_token": ["type": "string", "description": "The token from metadata.undo_token of the write to reverse."],
+                "dry_run": ["type": "boolean", "description": "When true, report what the undo would do and leave the token unspent. Default false."]
+            ], required: ["undo_token"])
         ),
         MCPTool(
             name: .contactsSearch,

--- a/Sources/M3MCPCore/CalendarUndo.swift
+++ b/Sources/M3MCPCore/CalendarUndo.swift
@@ -1,0 +1,260 @@
+import Foundation
+
+/// The event fields AppleMCP is able to write, and therefore the only ones it is able to put back.
+///
+/// Anything a calendar can hold that is not in this list (attendees, attachments, availability,
+/// recurrence rules, travel time) is outside the undo contract because it is also outside the
+/// write contract. An undo restores what these tools changed, not the event in full.
+public enum M3MCPCalendarField: String, CaseIterable, Sendable {
+    case title
+    case allDay
+    case start
+    case end
+    case location
+    case url
+    case notes
+    case calendar
+}
+
+/// The value a field held before a write.
+///
+/// `cleared` is not the same as "absent from the record": it says the field had no value, which is
+/// exactly the state an undo has to be able to restore. Collapsing the two into an optional would
+/// make "there was no location" indistinguishable from "location was never touched", and an undo
+/// would silently keep a location the update introduced.
+public enum M3MCPCalendarPreviousValue: Equatable, Sendable {
+    case text(String)
+    case cleared
+    case flag(Bool)
+    case timestamp(Date)
+}
+
+/// Everything needed to build the event again after it has been removed.
+public struct M3MCPCalendarEventSnapshot: Equatable, Sendable {
+    public var title: String?
+    public var isAllDay: Bool
+    public var startDate: Date?
+    public var endDate: Date?
+    public var location: String?
+    public var url: String?
+    public var notes: String?
+    public var calendarIdentifier: String?
+    /// Relative alarm offsets in seconds, negative for "before the start".
+    public var alarmOffsetsSeconds: [Double]
+
+    public init(
+        title: String? = nil,
+        isAllDay: Bool = false,
+        startDate: Date? = nil,
+        endDate: Date? = nil,
+        location: String? = nil,
+        url: String? = nil,
+        notes: String? = nil,
+        calendarIdentifier: String? = nil,
+        alarmOffsetsSeconds: [Double] = []
+    ) {
+        self.title = title
+        self.isAllDay = isAllDay
+        self.startDate = startDate
+        self.endDate = endDate
+        self.location = location
+        self.url = url
+        self.notes = notes
+        self.calendarIdentifier = calendarIdentifier
+        self.alarmOffsetsSeconds = alarmOffsetsSeconds
+    }
+}
+
+/// What has to happen to put one committed write back.
+public enum M3MCPCalendarUndoAction: Equatable, Sendable {
+    /// Undo of a create: remove the event that was just created.
+    case removeCreatedEvent(eventIdentifier: String)
+    /// Undo of an update: write the recorded previous values back over the changed fields only.
+    case restorePreviousValues(
+        eventIdentifier: String,
+        previous: [M3MCPCalendarField: M3MCPCalendarPreviousValue]
+    )
+    /// Undo of a delete: build the event again from its full snapshot.
+    case recreateDeletedEvent(M3MCPCalendarEventSnapshot)
+}
+
+/// One committed write, with the way back.
+public struct M3MCPCalendarUndoRecord: Equatable, Sendable {
+    public let token: String
+    public let tool: M3MCPToolName
+    /// A short, already-bounded description of the write this reverses, for the undo response and
+    /// the approval sheet.
+    public let summary: String
+    public let action: M3MCPCalendarUndoAction
+    public let recordedAt: Date
+    public let expiresAt: Date
+
+    /// False when the undo cannot give the event its identifier back. Recreating a deleted event
+    /// produces a new `eventIdentifier`, so anything that stored the old one still points at
+    /// nothing. Callers are told this before they act on it, not after.
+    public var restoresIdentifier: Bool {
+        if case .recreateDeletedEvent = action { return false }
+        return true
+    }
+
+    public init(
+        token: String,
+        tool: M3MCPToolName,
+        summary: String,
+        action: M3MCPCalendarUndoAction,
+        recordedAt: Date,
+        expiresAt: Date
+    ) {
+        self.token = token
+        self.tool = tool
+        self.summary = summary
+        self.action = action
+        self.recordedAt = recordedAt
+        self.expiresAt = expiresAt
+    }
+}
+
+/// The short-lived record of what the last few calendar writes replaced.
+///
+/// Approval stops a write nobody asked for. It does nothing about a write somebody asked for and got
+/// wrong: the sheet is a yes/no on arguments, and once it is answered the previous state is gone.
+/// This journal keeps that state for as long as a correction is plausible and no longer.
+///
+/// Deliberately in memory only. The snapshots hold event titles, notes, and locations, and writing
+/// them to disk would create a second copy of calendar content outside the calendar, with its own
+/// lifetime and its own way of leaking. Restarting the app therefore drops every token, which is
+/// stated in the tool description rather than left to be discovered.
+///
+/// Bounded twice, because both bounds fail differently: capacity keeps a client that writes in a
+/// loop from growing the process, and the lifetime keeps a token from reviving an hours-old state on
+/// top of newer, deliberate edits.
+public actor M3MCPCalendarUndoJournal {
+    public static let defaultCapacity = 20
+    public static let defaultLifetime: TimeInterval = 30 * 60
+
+    /// What a token resolves to. The three misses stay apart because they call for different things
+    /// from the caller: one has already been acted on, one is too late, one is wrong.
+    public enum Lookup: Equatable, Sendable {
+        case found(M3MCPCalendarUndoRecord)
+        case alreadyUndone
+        case expired
+        case unknown
+    }
+
+    private let capacity: Int
+    private let lifetime: TimeInterval
+    private let now: @Sendable () -> Date
+    private let makeToken: @Sendable () -> String
+
+    /// Insertion-ordered, oldest first.
+    private var records: [M3MCPCalendarUndoRecord] = []
+
+    public init(
+        capacity: Int = defaultCapacity,
+        lifetime: TimeInterval = defaultLifetime,
+        now: @escaping @Sendable () -> Date = { Date() },
+        makeToken: @escaping @Sendable () -> String = { "cal-undo-" + UUID().uuidString.lowercased() }
+    ) {
+        self.capacity = max(1, capacity)
+        self.lifetime = max(1, lifetime)
+        self.now = now
+        self.makeToken = makeToken
+    }
+
+    @discardableResult
+    public func record(
+        tool: M3MCPToolName,
+        summary: String,
+        action: M3MCPCalendarUndoAction
+    ) -> M3MCPCalendarUndoRecord {
+        let timestamp = now()
+        let record = M3MCPCalendarUndoRecord(
+            token: makeToken(),
+            tool: tool,
+            summary: summary,
+            action: action,
+            recordedAt: timestamp,
+            expiresAt: timestamp.addingTimeInterval(lifetime)
+        )
+        dropExpired()
+        records.append(record)
+        while records.count > capacity {
+            records.removeFirst()
+        }
+        return record
+    }
+
+    /// Reads a token without spending it. This is what a dry-run undo uses, so that previewing a
+    /// correction does not consume the only chance to make it.
+    public func peek(token: String) -> Lookup {
+        dropExpired()
+        guard let record = records.first(where: { $0.token == token }) else {
+            return miss(token)
+        }
+        return .found(record)
+    }
+
+    /// Spends a token. Single use: an undo that has run cannot run again, so a retried or replayed
+    /// call cannot delete a second, newer event that happens to sit at the same identifier.
+    public func consume(token: String) -> Lookup {
+        dropExpired()
+        guard let index = records.firstIndex(where: { $0.token == token }) else {
+            return miss(token)
+        }
+        let record = records.remove(at: index)
+        remember(token, in: &consumedTokens)
+        return .found(record)
+    }
+
+    /// Puts a consumed record back when the undo it was spent on did not happen.
+    ///
+    /// Without this, a failed undo would be worse than no undo: the token is gone, the state is
+    /// unchanged, and the caller has lost the only way back. Expired records stay dropped, so this
+    /// cannot extend a lifetime.
+    public func reinstate(_ record: M3MCPCalendarUndoRecord) {
+        guard record.expiresAt > now() else { return }
+        guard !records.contains(where: { $0.token == record.token }) else { return }
+        consumedTokens.remove(record.token)
+        records.append(record)
+        while records.count > capacity {
+            records.removeFirst()
+        }
+    }
+
+    public var count: Int {
+        records.count
+    }
+
+    /// Token names only, so a miss can be reported for what it is instead of as "unknown". No
+    /// snapshot content survives in either set: no title, no notes, no location.
+    private var expiredTokens: Set<String> = []
+    private var consumedTokens: Set<String> = []
+
+    private func dropExpired() {
+        let current = now()
+        var stillValid: [M3MCPCalendarUndoRecord] = []
+        stillValid.reserveCapacity(records.count)
+        for record in records {
+            if record.expiresAt > current {
+                stillValid.append(record)
+            } else {
+                remember(record.token, in: &expiredTokens)
+            }
+        }
+        records = stillValid
+    }
+
+    private func miss(_ token: String) -> Lookup {
+        if consumedTokens.contains(token) { return .alreadyUndone }
+        if expiredTokens.contains(token) { return .expired }
+        return .unknown
+    }
+
+    /// Bounded like the journal itself: these sets are a diagnostic, not a ledger.
+    private func remember(_ token: String, in set: inout Set<String>) {
+        set.insert(token)
+        while set.count > capacity * 4, let evictable = set.first(where: { $0 != token }) {
+            set.remove(evictable)
+        }
+    }
+}

--- a/Sources/M3MCPCore/InteractiveApproval.swift
+++ b/Sources/M3MCPCore/InteractiveApproval.swift
@@ -8,9 +8,19 @@ public struct M3MCPToolApprovalRequest: Equatable, Sendable {
     public let tool: M3MCPToolName
     public let argumentPreview: String
 
+    /// What the call would do, when the arguments do not say.
+    ///
+    /// `calendar_undo_write` is the case that forced this. Its only argument is an opaque token, and
+    /// "token" is a redacted key, so the sheet had nothing on it but `undo_token: [REDACTED]`. A
+    /// decision needs the effect, not the handle: this carries the recorded summary of the write
+    /// that would be reversed. It is server-side text, never client-supplied, and it is bounded the
+    /// same way the argument preview is.
+    public let effectPreview: String?
+
     public init(
         tool: M3MCPToolName,
         input: [String: JSONValue],
+        effectPreview: String? = nil,
         maximumPreviewCharacters: Int = M3MCPInteractiveApproval.defaultMaximumPreviewCharacters
     ) {
         self.tool = tool
@@ -18,6 +28,12 @@ public struct M3MCPToolApprovalRequest: Equatable, Sendable {
             input,
             maximumCharacters: maximumPreviewCharacters
         )
+        self.effectPreview = effectPreview.map {
+            M3MCPInteractiveApproval.boundedEffectPreview(
+                $0,
+                maximumCharacters: maximumPreviewCharacters
+            )
+        }
     }
 }
 
@@ -104,6 +120,18 @@ public enum M3MCPInteractiveApproval {
                 maximumCharacters: lineBudget - prefix.count
             )
         }.joined(separator: "\n")
+    }
+
+    /// Escapes and bounds server-authored effect text with the same rules the argument preview uses,
+    /// so a title copied out of a calendar cannot smuggle control characters into the sheet.
+    public static func boundedEffectPreview(
+        _ text: String,
+        maximumCharacters: Int = defaultMaximumPreviewCharacters
+    ) -> String {
+        bounded(
+            boundedEscapedString(text, maximumCharacters: max(0, maximumCharacters)),
+            maximumCharacters: max(0, maximumCharacters)
+        )
     }
 
     private static let sensitiveKeyFragments: [String] = [

--- a/Sources/M3MCPCore/InteractiveApproval.swift
+++ b/Sources/M3MCPCore/InteractiveApproval.swift
@@ -39,6 +39,32 @@ public enum M3MCPInteractiveApproval {
         }
     }
 
+    /// The same question, asked of a concrete call.
+    ///
+    /// A dry run changes nothing, so there is nothing to consent to; requiring a click to see what a
+    /// write would do would make the preview useless in exactly the case it is for: a client
+    /// working out which event it means before asking a human anything. The exemption is narrow on
+    /// purpose:
+    ///
+    /// - only the literal boolean `true` reaches it, every other shape having been rejected by
+    ///   `M3MCPToolArgumentPolicy` first,
+    /// - only for a tool whose reviewed argument policy actually declares `dry_run`, so a tool that
+    ///   never learned to preview cannot be talked out of its sheet by an unexpected key, and
+    /// - it is the same value the provider reads, from the same function, so "no sheet" and "no
+    ///   write" cannot come apart.
+    ///
+    /// What it does not weaken: the launch-time opt-in still gates the whole group, so a preview is
+    /// only reachable where the mutation group was enabled at launch. It reveals no more about the
+    /// calendar than the default-safe read tools already do.
+    public static func requiresApproval(for tool: M3MCPToolName, input: [String: JSONValue]) -> Bool {
+        guard requiresApproval(for: tool) else { return false }
+        guard M3MCPToolArgumentPolicy
+            .forTool(tool)
+            .allowedKeys
+            .contains(M3MCPWriteIntent.parameterName) else { return true }
+        return M3MCPWriteIntent.resolve(from: input).writes
+    }
+
     /// Produces a stable, bounded preview for a native approval dialog.
     ///
     /// Keys are sorted, nested objects remain sorted, control characters are escaped, long values

--- a/Sources/M3MCPCore/SecurityPolicy.swift
+++ b/Sources/M3MCPCore/SecurityPolicy.swift
@@ -57,7 +57,10 @@ public struct M3MCPSecurityPolicy: Equatable, Sendable {
         case localProcessing
         /// Generates an app-owned local artifact without launching UI or arbitrary automation.
         case localGeneration
-        /// Creates, updates, or irreversibly deletes Calendar data.
+        /// Creates, updates, or deletes Calendar data.
+        ///
+        /// A single event write records what it replaced and can be reversed once through
+        /// `calendar_undo_write`. Deleting a calendar cannot: it takes its events with it.
         case calendarMutation
         /// Requests a macOS permission or opens System Settings.
         case permissionUI

--- a/Sources/M3MCPCore/SecurityPolicy.swift
+++ b/Sources/M3MCPCore/SecurityPolicy.swift
@@ -19,6 +19,7 @@ public enum M3MCPToolName: String, CaseIterable, Sendable {
     case calendarDeleteEvent = "calendar_delete_event"
     case calendarCreateCalendar = "calendar_create_calendar"
     case calendarDeleteCalendar = "calendar_delete_calendar"
+    case calendarUndoWrite = "calendar_undo_write"
 
     case contactsSearch = "contacts_search"
     case mailSearch = "mail_search"
@@ -172,7 +173,8 @@ public struct M3MCPSecurityPolicy: Equatable, Sendable {
              .calendarUpdateEvent,
              .calendarDeleteEvent,
              .calendarCreateCalendar,
-             .calendarDeleteCalendar:
+             .calendarDeleteCalendar,
+             .calendarUndoWrite:
             return .calendarMutation
 
         case .permissionsRequest,
@@ -210,7 +212,7 @@ public struct M3MCPSecurityPolicy: Equatable, Sendable {
     }
 
     /// Every reviewed tool exactly once, annotated with its state under this launch policy.
-    /// Default-safe callers therefore receive 21 enabled rows plus the nine explicit opt-ins,
+    /// Default-safe callers therefore receive 21 enabled rows plus the ten explicit opt-ins,
     /// without maintaining a second UI catalog.
     public var toolAvailability: [ToolAvailability] {
         M3MCPToolName.allCases.map { tool in

--- a/Sources/M3MCPCore/ToolArgumentPolicy.swift
+++ b/Sources/M3MCPCore/ToolArgumentPolicy.swift
@@ -127,7 +127,7 @@ public struct M3MCPToolArgumentPolicy: Equatable, Sendable {
                     "url", "project_slug"
                 ],
                 integers: ["duration_minutes", "alarm_minutes_before"],
-                booleans: ["all_day"],
+                booleans: ["all_day", M3MCPWriteIntent.parameterName],
                 required: ["title", "start"],
                 requiredAlternatives: [["calendar_id"], ["calendar"]]
             )
@@ -139,18 +139,37 @@ public struct M3MCPToolArgumentPolicy: Equatable, Sendable {
                     "calendar", "calendar_id", "span"
                 ],
                 integers: ["duration_minutes"],
-                booleans: ["all_day"],
+                booleans: ["all_day", M3MCPWriteIntent.parameterName],
                 required: ["id"]
             )
 
         case .calendarDeleteEvent:
-            return policy(strings: ["id", "span"], required: ["id"])
+            return policy(
+                strings: ["id", "span"],
+                booleans: [M3MCPWriteIntent.parameterName],
+                required: ["id"]
+            )
 
         case .calendarCreateCalendar:
-            return policy(strings: ["title", "source"], required: ["title"])
+            return policy(
+                strings: ["title", "source"],
+                booleans: [M3MCPWriteIntent.parameterName],
+                required: ["title"]
+            )
 
         case .calendarDeleteCalendar:
-            return policy(strings: ["id", "title"], required: ["id", "title"])
+            return policy(
+                strings: ["id", "title"],
+                booleans: [M3MCPWriteIntent.parameterName],
+                required: ["id", "title"]
+            )
+
+        case .calendarUndoWrite:
+            return policy(
+                strings: ["undo_token"],
+                booleans: [M3MCPWriteIntent.parameterName],
+                required: ["undo_token"]
+            )
 
         case .contactsSearch:
             return queryPolicy()

--- a/Sources/M3MCPCore/ToolSecurityHints.swift
+++ b/Sources/M3MCPCore/ToolSecurityHints.swift
@@ -62,6 +62,17 @@ public struct M3MCPToolSecurityHints: Equatable, Sendable {
                     idempotent: true,
                     openWorld: true
                 )
+            case .calendarUndoWrite:
+                // Destructive because reversing a create removes an event, and because reversing an
+                // update overwrites whatever the field holds now. Idempotent because the token is
+                // spent on first use: a repeated call reports that it was already undone rather
+                // than acting a second time.
+                return M3MCPToolSecurityHints(
+                    readOnly: false,
+                    destructive: true,
+                    idempotent: true,
+                    openWorld: true
+                )
             default:
                 // Future policy/catalog drift must fail safely without making tools/list crash.
                 return M3MCPToolSecurityHints(

--- a/Sources/M3MCPCore/WriteIntent.swift
+++ b/Sources/M3MCPCore/WriteIntent.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Whether a write tool is being asked to preview a change or to perform it.
+///
+/// Before this existed, the only way to see what a mutation would do was to let it happen and read
+/// the result back. The per-call approval sheet showed the arguments, not the effect: it could not
+/// say which calendar a title resolves to, what an omitted `end` becomes, or which event an id
+/// actually names. A caller who wanted that answer had to commit first.
+///
+/// `dry_run` is a separate question from consent, which is why it is a separate parameter rather
+/// than a side effect of a missing confirmation. It resolves the same arguments, applies the same
+/// validation, and reports the same target, and then stops.
+///
+/// The default is `commit`. An absent, false, or non-boolean value keeps the previous behaviour, so
+/// no existing caller silently turns into a no-op. Only the literal boolean `true` selects a preview;
+/// `M3MCPToolArgumentPolicy` has already rejected every other shape by the time this runs.
+public enum M3MCPWriteIntent: String, Equatable, Sendable {
+    case dryRun
+    case commit
+
+    public static let parameterName = "dry_run"
+
+    public static func resolve(from input: [String: JSONValue]) -> M3MCPWriteIntent {
+        if case .bool(true) = input[parameterName] ?? .null {
+            return .dryRun
+        }
+        return .commit
+    }
+
+    public var writes: Bool { self == .commit }
+
+    /// The `meta` entry every write tool sets, so a client can branch on the answer instead of
+    /// parsing the prose in `message`.
+    public var metaValue: String { self == .dryRun ? "true" : "false" }
+}

--- a/Tests/M3MCPAppTests/CalendarDryRunDispatchTests.swift
+++ b/Tests/M3MCPAppTests/CalendarDryRunDispatchTests.swift
@@ -1,0 +1,177 @@
+import EventKit
+import Foundation
+import XCTest
+@testable import M3MCPApp
+@testable import M3MCPCore
+
+/// Where the dry-run exemption actually lands: the app dispatcher.
+///
+/// `M3MCPInteractiveApproval` is unit-tested on its own, but the exemption is only worth anything if
+/// `LocalMCPService` asks the question with the arguments in hand. These calls go through the real
+/// dispatcher with a real security policy, and no approval UI at all: with none available a call
+/// that needs a sheet is denied outright, which makes the denial itself the signal.
+final class CalendarDryRunDispatchTests: XCTestCase {
+    private static let approvalDenial = "requires explicit local approval"
+
+    private func serviceWithoutApprovalUI() -> LocalMCPService {
+        LocalMCPService(
+            securityPolicy: M3MCPSecurityPolicy(
+                configuration: .init(allowCalendarMutations: true)
+            ),
+            approvalHandler: nil
+        )
+    }
+
+    private func writeCalls() -> [(String, [String: JSONValue])] {
+        [
+            (
+                M3MCPToolName.calendarCreateEvent.rawValue,
+                [
+                    "title": .string("Weekly review"),
+                    "start": .string("2026-09-08T10:00:00+02:00"),
+                    "duration_minutes": .number(30),
+                    "calendar_id": .string("calendar-that-does-not-exist")
+                ]
+            ),
+            (
+                M3MCPToolName.calendarUpdateEvent.rawValue,
+                ["id": .string("event-1"), "title": .string("Renamed")]
+            ),
+            (
+                M3MCPToolName.calendarDeleteEvent.rawValue,
+                ["id": .string("event-1")]
+            ),
+            (
+                M3MCPToolName.calendarCreateCalendar.rawValue,
+                ["title": .string("Scratch")]
+            ),
+            (
+                M3MCPToolName.calendarDeleteCalendar.rawValue,
+                ["id": .string("calendar-1"), "title": .string("Scratch")]
+            ),
+            (
+                M3MCPToolName.calendarUndoWrite.rawValue,
+                ["undo_token": .string("cal-undo-none")]
+            )
+        ]
+    }
+
+    func testACommitWithNoApprovalUIIsRefusedBeforeItReachesTheProvider() async {
+        let service = serviceWithoutApprovalUI()
+
+        for (tool, input) in writeCalls() {
+            let response = await service.handle(tool: tool, input: input)
+            XCTAssertFalse(response.ok, tool)
+            XCTAssertEqual(response.source, "M3MCP Interactive Approval", tool)
+            XCTAssertTrue(
+                response.message?.contains(Self.approvalDenial) == true,
+                "\(tool) must not run without a decision: \(response.message ?? "")"
+            )
+        }
+    }
+
+    func testADryRunIsNotStoppedByTheMissingApprovalUI() async {
+        let service = serviceWithoutApprovalUI()
+
+        for (tool, input) in writeCalls() {
+            var previewInput = input
+            previewInput["dry_run"] = .bool(true)
+
+            let response = await service.handle(tool: tool, input: previewInput)
+
+            // It gets past approval and into the provider, where this machine's Calendar
+            // authorization decides what happens next. What it must never be is the approval denial.
+            XCTAssertNotEqual(response.source, "M3MCP Interactive Approval", tool)
+            XCTAssertFalse(
+                response.message?.contains(Self.approvalDenial) == true,
+                "\(tool) preview was stopped by the approval gate: \(response.message ?? "")"
+            )
+        }
+    }
+
+    func testTheLaunchOptInStillGatesAPreview() async {
+        // Default-safe policy: the preview is not a way around the launch decision.
+        let service = LocalMCPService(securityPolicy: M3MCPSecurityPolicy())
+
+        let response = await service.handle(
+            tool: M3MCPToolName.calendarDeleteEvent.rawValue,
+            input: ["id": .string("event-1"), "dry_run": .bool(true)]
+        )
+
+        XCTAssertFalse(response.ok)
+        XCTAssertEqual(response.source, "M3MCP Security Policy")
+        XCTAssertTrue(
+            response.message?.contains("M3MCP_ENABLE_CALENDAR_MUTATIONS") == true,
+            response.message ?? ""
+        )
+    }
+
+    func testAStringDryRunIsRejectedByTheSchemaRatherThanTreatedAsAPreview() async {
+        let service = serviceWithoutApprovalUI()
+
+        let response = await service.handle(
+            tool: M3MCPToolName.calendarDeleteEvent.rawValue,
+            input: ["id": .string("event-1"), "dry_run": .string("true")]
+        )
+
+        XCTAssertFalse(response.ok)
+        XCTAssertEqual(response.source, "M3MCP Argument Validation")
+        XCTAssertTrue(response.message?.contains("must be a boolean") == true, response.message ?? "")
+    }
+
+    func testTheUndoSheetDescribesTheWriteRatherThanTheRedactedToken() async {
+        let provider = CalendarProvider()
+
+        // The argument the sheet would otherwise have to work with.
+        let preview = M3MCPInteractiveApproval.argumentPreview([
+            "undo_token": .string("cal-undo-3f9a")
+        ])
+        XCTAssertTrue(preview.contains("[REDACTED]"), preview)
+
+        let record = await provider.undoJournal.record(
+            tool: .calendarDeleteEvent,
+            summary: "deleting 'Weekly review' from 'Work'",
+            action: .recreateDeletedEvent(
+                M3MCPCalendarEventSnapshot(
+                    title: "Weekly review",
+                    startDate: Date(timeIntervalSince1970: 1_800_000_000),
+                    endDate: Date(timeIntervalSince1970: 1_800_003_600),
+                    calendarIdentifier: "calendar-1"
+                )
+            )
+        )
+
+        let effect = await provider.undoEffectDescription(
+            input: ["undo_token": .string(record.token)]
+        )
+        XCTAssertEqual(
+            effect,
+            "Reverses deleting 'Weekly review' from 'Work'. The event gets a new id."
+        )
+
+        // Reading it for the sheet must not spend it.
+        let stillThere = await provider.undoJournal.peek(token: record.token)
+        guard case .found = stillThere else {
+            return XCTFail("building the sheet text must not consume the token")
+        }
+
+        // A token that stands for nothing says so, so nobody approves an empty undo.
+        let missing = await provider.undoEffectDescription(
+            input: ["undo_token": .string("cal-undo-nothing")]
+        )
+        XCTAssertEqual(missing, "No snapshot matches this token. Nothing would be reversed.")
+    }
+
+    func testUndoRefusesAnEmptyTokenAndAnUnknownOneWithoutTouchingTheCalendar() async {
+        let provider = CalendarProvider()
+
+        let blank = await provider.undoWrite(input: ["undo_token": .string("   ")])
+        XCTAssertFalse(blank.ok)
+
+        // On a machine without Calendar authorization the access gate answers first, which is itself
+        // the guarantee under test: nothing reaches EventKit before that check.
+        if blank.message?.contains("Calendar access") != true {
+            XCTAssertTrue(blank.message?.contains("'undo_token' is required") == true, blank.message ?? "")
+        }
+    }
+}

--- a/Tests/M3MCPAppTests/CalendarUndoLiveTests.swift
+++ b/Tests/M3MCPAppTests/CalendarUndoLiveTests.swift
@@ -14,19 +14,23 @@ import XCTest
 /// - Calendar authorization already granted. The status is read, never requested: a test that raises
 ///   a TCC panel would hang a CI runner and pester a developer.
 ///
-/// Everything happens inside a calendar this test creates in the local ("On My Mac") source and
-/// removes again, so it never touches an account that syncs and never an event that was already
-/// there. Without a local source the test skips rather than fall back to a synced account.
+/// Everything goes through one `CalendarProvider`, and therefore one `EKEventStore`, including the
+/// setup and the read-backs. Reading through a second store instance would leave the result
+/// depending on when EventKit propagates a save between stores, which is a property of the framework
+/// and not of this code.
+///
+/// The scratch calendar is created by `calendar_create_calendar`, which defaults to the local
+/// ("On My Mac") source, so nothing here reaches an account that syncs. Without a local source the
+/// tool refuses and this test skips.
 final class CalendarUndoLiveTests: XCTestCase {
     private static let environmentKey = "M3MCP_CALENDAR_UNDO_LIVE"
     private static let calendarTitle = "M3MCP Undo Verification"
 
-    private var store: EKEventStore!
-    private var calendar: EKCalendar!
     private var provider: CalendarProvider!
+    private var calendarID: String!
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    override func setUp() async throws {
+        try await super.setUp()
 
         try XCTSkipUnless(
             ProcessInfo.processInfo.environment[Self.environmentKey] == "1",
@@ -37,27 +41,38 @@ final class CalendarUndoLiveTests: XCTestCase {
             "Calendar authorization is \(Self.statusName). This test reads the status and never requests it, so grant full access in System Settings first."
         )
 
-        store = EKEventStore()
-        guard let localSource = store.sources.first(where: { $0.sourceType == .local }) else {
-            throw XCTSkip("No local calendar source, and this test refuses to write into a synced account.")
-        }
-
-        let created = EKCalendar(for: .event, eventStore: store)
-        created.title = Self.calendarTitle
-        created.source = localSource
-        try store.saveCalendar(created, commit: true)
-        calendar = created
         provider = CalendarProvider()
+
+        // A leftover calendar from an interrupted run would make the create fail on the duplicate
+        // title, so it is removed first.
+        await removeScratchCalendar()
+
+        let created = await provider.createCalendar(input: [
+            "title": .string(Self.calendarTitle)
+        ])
+        guard created.ok, let id = created.items.first?.id else {
+            throw XCTSkip("Could not create a local scratch calendar: \(created.message ?? "no message")")
+        }
+        calendarID = id
     }
 
-    override func tearDownWithError() throws {
-        if let calendar, let store {
-            try? store.removeCalendar(calendar, commit: true)
+    override func tearDown() async throws {
+        if provider != nil {
+            await removeScratchCalendar()
         }
         provider = nil
-        calendar = nil
-        store = nil
-        try super.tearDownWithError()
+        calendarID = nil
+        try await super.tearDown()
+    }
+
+    private func removeScratchCalendar() async {
+        let listed = await provider.listCalendars(input: ["query": .string(Self.calendarTitle)])
+        for item in listed.items where item.title == Self.calendarTitle {
+            _ = await provider.deleteCalendar(input: [
+                "id": .string(item.id),
+                "title": .string(Self.calendarTitle)
+            ])
+        }
     }
 
     private static var statusName: String {
@@ -78,7 +93,7 @@ final class CalendarUndoLiveTests: XCTestCase {
             "duration_minutes": .number(45),
             "location": .string("Room 3"),
             "notes": .string("live undo verification"),
-            "calendar_id": .string(calendar.calendarIdentifier)
+            "calendar_id": .string(calendarID)
         ])
 
         XCTAssertTrue(response.ok, response.message ?? "")
@@ -87,17 +102,22 @@ final class CalendarUndoLiveTests: XCTestCase {
         return (id, token)
     }
 
+    /// Read-back through the same provider, so the assertions are about the write and not about
+    /// cross-store propagation.
+    private func readEvent(_ id: String) async -> DataItem? {
+        let response = await provider.readEvent(input: ["id": .string(id)])
+        return response.ok ? response.items.first : nil
+    }
+
     func testADeletedEventComesBackWithItsContentAndANewIdentifier() async throws {
         let created = try await createEvent(title: "Delete and restore")
-        let before = try XCTUnwrap(store.event(withIdentifier: created.id))
-        let title = before.title
-        let start = before.startDate
-        let end = before.endDate
-        let location = before.location
+        let beforeItem = await readEvent(created.id)
+        let before = try XCTUnwrap(beforeItem)
 
         let deletion = await provider.deleteEvent(input: ["id": .string(created.id)])
         XCTAssertTrue(deletion.ok, deletion.message ?? "")
-        XCTAssertNil(store.event(withIdentifier: created.id), "the delete must really have happened")
+        let gone = await readEvent(created.id)
+        XCTAssertNil(gone, "the delete must really have happened")
 
         let token = try XCTUnwrap(deletion.meta?["undo_token"])
         XCTAssertEqual(deletion.meta?["undo_restores_identifier"], "false")
@@ -108,17 +128,19 @@ final class CalendarUndoLiveTests: XCTestCase {
         let restoredID = try XCTUnwrap(undo.items.first?.id)
         XCTAssertNotEqual(restoredID, created.id, "EventKit cannot return the old identifier")
 
-        let restored = try XCTUnwrap(store.event(withIdentifier: restoredID))
-        XCTAssertEqual(restored.title, title)
-        XCTAssertEqual(restored.startDate, start)
-        XCTAssertEqual(restored.endDate, end)
-        XCTAssertEqual(restored.location, location)
-        XCTAssertEqual(restored.calendar.calendarIdentifier, calendar.calendarIdentifier)
+        let restoredItem = await readEvent(restoredID)
+        let restored = try XCTUnwrap(restoredItem)
+        XCTAssertEqual(restored.title, before.title)
+        XCTAssertEqual(restored.metadata["start"], before.metadata["start"])
+        XCTAssertEqual(restored.metadata["end"], before.metadata["end"])
+        XCTAssertEqual(restored.subtitle, before.subtitle, "location")
+        XCTAssertEqual(restored.metadata["calendar_id"], calendarID)
 
         // Single use: the token is spent and a replay must not remove the restored event.
         let replay = await provider.undoWrite(input: ["undo_token": .string(token)])
         XCTAssertFalse(replay.ok)
-        XCTAssertNotNil(store.event(withIdentifier: restoredID))
+        let survived = await readEvent(restoredID)
+        XCTAssertNotNil(survived)
     }
 
     func testAChangedEventGoesBackToItsPreviousValues() async throws {
@@ -131,9 +153,10 @@ final class CalendarUndoLiveTests: XCTestCase {
         ])
         XCTAssertTrue(update.ok, update.message ?? "")
 
-        let changed = try XCTUnwrap(store.event(withIdentifier: created.id))
+        let changedItem = await readEvent(created.id)
+        let changed = try XCTUnwrap(changedItem)
         XCTAssertEqual(changed.title, "Changed by mistake")
-        XCTAssertEqual(changed.location, "Room 9")
+        XCTAssertEqual(changed.subtitle, "Room 9")
 
         let token = try XCTUnwrap(update.meta?["undo_token"])
         XCTAssertEqual(update.meta?["undo_restores_identifier"], "true")
@@ -141,11 +164,12 @@ final class CalendarUndoLiveTests: XCTestCase {
         let undo = await provider.undoWrite(input: ["undo_token": .string(token)])
         XCTAssertTrue(undo.ok, undo.message ?? "")
 
-        let restored = try XCTUnwrap(store.event(withIdentifier: created.id))
+        let restoredItem = await readEvent(created.id)
+        let restored = try XCTUnwrap(restoredItem)
         XCTAssertEqual(restored.title, "Update and restore")
-        XCTAssertEqual(restored.location, "Room 3")
+        XCTAssertEqual(restored.subtitle, "Room 3")
         // A field the update never touched must not be dragged along by the undo.
-        XCTAssertEqual(restored.notes, "live undo verification")
+        XCTAssertEqual(restored.preview, "live undo verification")
     }
 
     func testAPreviewLeavesTheCalendarExactlyAsItWas() async throws {
@@ -158,7 +182,8 @@ final class CalendarUndoLiveTests: XCTestCase {
         XCTAssertTrue(deletePreview.ok, deletePreview.message ?? "")
         XCTAssertEqual(deletePreview.meta?["dry_run"], "true")
         XCTAssertNil(deletePreview.meta?["undo_token"])
-        XCTAssertNotNil(store.event(withIdentifier: created.id), "a preview must not delete")
+        let stillThere = await readEvent(created.id)
+        XCTAssertNotNil(stillThere, "a preview must not delete")
 
         let updatePreview = await provider.updateEvent(input: [
             "id": .string(created.id),
@@ -168,14 +193,15 @@ final class CalendarUndoLiveTests: XCTestCase {
         XCTAssertTrue(updatePreview.ok, updatePreview.message ?? "")
         XCTAssertEqual(updatePreview.meta?["would_change"], "title")
 
-        let untouched = try XCTUnwrap(store.event(withIdentifier: created.id))
+        let untouchedItem = await readEvent(created.id)
+        let untouched = try XCTUnwrap(untouchedItem)
         XCTAssertEqual(untouched.title, "Preview only", "a preview must not write, not even in memory")
 
         let createPreview = await provider.createEvent(input: [
             "title": .string("Never created"),
             "start": .string("2031-04-08T09:00:00+02:00"),
             "duration_minutes": .number(30),
-            "calendar_id": .string(calendar.calendarIdentifier),
+            "calendar_id": .string(calendarID),
             "dry_run": .bool(true)
         ])
         XCTAssertTrue(createPreview.ok, createPreview.message ?? "")
@@ -183,7 +209,7 @@ final class CalendarUndoLiveTests: XCTestCase {
 
         let search = await provider.search(input: [
             "query": .string("Never created"),
-            "calendar": .string(calendar.calendarIdentifier),
+            "calendar": .string(calendarID),
             "start_days": .number(-3_650),
             "end_days": .number(3_650)
         ])
@@ -192,10 +218,12 @@ final class CalendarUndoLiveTests: XCTestCase {
 
     func testACreatedEventCanBeTakenBack() async throws {
         let created = try await createEvent(title: "Created by mistake")
-        XCTAssertNotNil(store.event(withIdentifier: created.id))
+        let present = await readEvent(created.id)
+        XCTAssertNotNil(present)
 
         let undo = await provider.undoWrite(input: ["undo_token": .string(created.undoToken)])
         XCTAssertTrue(undo.ok, undo.message ?? "")
-        XCTAssertNil(store.event(withIdentifier: created.id), "undoing a create must remove the event")
+        let gone = await readEvent(created.id)
+        XCTAssertNil(gone, "undoing a create must remove the event")
     }
 }

--- a/Tests/M3MCPAppTests/CalendarUndoLiveTests.swift
+++ b/Tests/M3MCPAppTests/CalendarUndoLiveTests.swift
@@ -1,0 +1,201 @@
+import EventKit
+import Foundation
+import M3MCPCore
+import XCTest
+@testable import M3MCPApp
+
+/// The half of the undo contract that only a real calendar can answer: does a deleted event come
+/// back, and does a changed one go back.
+///
+/// Two conditions, both required, neither of them prompting:
+///
+/// - `M3MCP_CALENDAR_UNDO_LIVE=1`, because this writes to the machine's Calendar database and nobody
+///   should discover that by running `swift test`.
+/// - Calendar authorization already granted. The status is read, never requested: a test that raises
+///   a TCC panel would hang a CI runner and pester a developer.
+///
+/// Everything happens inside a calendar this test creates in the local ("On My Mac") source and
+/// removes again, so it never touches an account that syncs and never an event that was already
+/// there. Without a local source the test skips rather than fall back to a synced account.
+final class CalendarUndoLiveTests: XCTestCase {
+    private static let environmentKey = "M3MCP_CALENDAR_UNDO_LIVE"
+    private static let calendarTitle = "M3MCP Undo Verification"
+
+    private var store: EKEventStore!
+    private var calendar: EKCalendar!
+    private var provider: CalendarProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment[Self.environmentKey] == "1",
+            "Live calendar round trip is opt-in. Set \(Self.environmentKey)=1 to write to the real Calendar database."
+        )
+        try XCTSkipUnless(
+            EKEventStore.authorizationStatus(for: .event) == .fullAccess,
+            "Calendar authorization is \(Self.statusName). This test reads the status and never requests it, so grant full access in System Settings first."
+        )
+
+        store = EKEventStore()
+        guard let localSource = store.sources.first(where: { $0.sourceType == .local }) else {
+            throw XCTSkip("No local calendar source, and this test refuses to write into a synced account.")
+        }
+
+        let created = EKCalendar(for: .event, eventStore: store)
+        created.title = Self.calendarTitle
+        created.source = localSource
+        try store.saveCalendar(created, commit: true)
+        calendar = created
+        provider = CalendarProvider()
+    }
+
+    override func tearDownWithError() throws {
+        if let calendar, let store {
+            try? store.removeCalendar(calendar, commit: true)
+        }
+        provider = nil
+        calendar = nil
+        store = nil
+        try super.tearDownWithError()
+    }
+
+    private static var statusName: String {
+        switch EKEventStore.authorizationStatus(for: .event) {
+        case .notDetermined: return "not determined"
+        case .restricted: return "restricted"
+        case .denied: return "denied"
+        case .fullAccess: return "full access"
+        case .writeOnly: return "write only"
+        @unknown default: return "unrecognised"
+        }
+    }
+
+    private func createEvent(title: String) async throws -> (id: String, undoToken: String) {
+        let response = await provider.createEvent(input: [
+            "title": .string(title),
+            "start": .string("2031-04-07T09:00:00+02:00"),
+            "duration_minutes": .number(45),
+            "location": .string("Room 3"),
+            "notes": .string("live undo verification"),
+            "calendar_id": .string(calendar.calendarIdentifier)
+        ])
+
+        XCTAssertTrue(response.ok, response.message ?? "")
+        let id = try XCTUnwrap(response.items.first?.id)
+        let token = try XCTUnwrap(response.meta?["undo_token"])
+        return (id, token)
+    }
+
+    func testADeletedEventComesBackWithItsContentAndANewIdentifier() async throws {
+        let created = try await createEvent(title: "Delete and restore")
+        let before = try XCTUnwrap(store.event(withIdentifier: created.id))
+        let title = before.title
+        let start = before.startDate
+        let end = before.endDate
+        let location = before.location
+
+        let deletion = await provider.deleteEvent(input: ["id": .string(created.id)])
+        XCTAssertTrue(deletion.ok, deletion.message ?? "")
+        XCTAssertNil(store.event(withIdentifier: created.id), "the delete must really have happened")
+
+        let token = try XCTUnwrap(deletion.meta?["undo_token"])
+        XCTAssertEqual(deletion.meta?["undo_restores_identifier"], "false")
+
+        let undo = await provider.undoWrite(input: ["undo_token": .string(token)])
+        XCTAssertTrue(undo.ok, undo.message ?? "")
+
+        let restoredID = try XCTUnwrap(undo.items.first?.id)
+        XCTAssertNotEqual(restoredID, created.id, "EventKit cannot return the old identifier")
+
+        let restored = try XCTUnwrap(store.event(withIdentifier: restoredID))
+        XCTAssertEqual(restored.title, title)
+        XCTAssertEqual(restored.startDate, start)
+        XCTAssertEqual(restored.endDate, end)
+        XCTAssertEqual(restored.location, location)
+        XCTAssertEqual(restored.calendar.calendarIdentifier, calendar.calendarIdentifier)
+
+        // Single use: the token is spent and a replay must not remove the restored event.
+        let replay = await provider.undoWrite(input: ["undo_token": .string(token)])
+        XCTAssertFalse(replay.ok)
+        XCTAssertNotNil(store.event(withIdentifier: restoredID))
+    }
+
+    func testAChangedEventGoesBackToItsPreviousValues() async throws {
+        let created = try await createEvent(title: "Update and restore")
+
+        let update = await provider.updateEvent(input: [
+            "id": .string(created.id),
+            "title": .string("Changed by mistake"),
+            "location": .string("Room 9")
+        ])
+        XCTAssertTrue(update.ok, update.message ?? "")
+
+        let changed = try XCTUnwrap(store.event(withIdentifier: created.id))
+        XCTAssertEqual(changed.title, "Changed by mistake")
+        XCTAssertEqual(changed.location, "Room 9")
+
+        let token = try XCTUnwrap(update.meta?["undo_token"])
+        XCTAssertEqual(update.meta?["undo_restores_identifier"], "true")
+
+        let undo = await provider.undoWrite(input: ["undo_token": .string(token)])
+        XCTAssertTrue(undo.ok, undo.message ?? "")
+
+        let restored = try XCTUnwrap(store.event(withIdentifier: created.id))
+        XCTAssertEqual(restored.title, "Update and restore")
+        XCTAssertEqual(restored.location, "Room 3")
+        // A field the update never touched must not be dragged along by the undo.
+        XCTAssertEqual(restored.notes, "live undo verification")
+    }
+
+    func testAPreviewLeavesTheCalendarExactlyAsItWas() async throws {
+        let created = try await createEvent(title: "Preview only")
+
+        let deletePreview = await provider.deleteEvent(input: [
+            "id": .string(created.id),
+            "dry_run": .bool(true)
+        ])
+        XCTAssertTrue(deletePreview.ok, deletePreview.message ?? "")
+        XCTAssertEqual(deletePreview.meta?["dry_run"], "true")
+        XCTAssertNil(deletePreview.meta?["undo_token"])
+        XCTAssertNotNil(store.event(withIdentifier: created.id), "a preview must not delete")
+
+        let updatePreview = await provider.updateEvent(input: [
+            "id": .string(created.id),
+            "title": .string("Not written"),
+            "dry_run": .bool(true)
+        ])
+        XCTAssertTrue(updatePreview.ok, updatePreview.message ?? "")
+        XCTAssertEqual(updatePreview.meta?["would_change"], "title")
+
+        let untouched = try XCTUnwrap(store.event(withIdentifier: created.id))
+        XCTAssertEqual(untouched.title, "Preview only", "a preview must not write, not even in memory")
+
+        let createPreview = await provider.createEvent(input: [
+            "title": .string("Never created"),
+            "start": .string("2031-04-08T09:00:00+02:00"),
+            "duration_minutes": .number(30),
+            "calendar_id": .string(calendar.calendarIdentifier),
+            "dry_run": .bool(true)
+        ])
+        XCTAssertTrue(createPreview.ok, createPreview.message ?? "")
+        XCTAssertNil(createPreview.meta?["undo_token"])
+
+        let search = await provider.search(input: [
+            "query": .string("Never created"),
+            "calendar": .string(calendar.calendarIdentifier),
+            "start_days": .number(-3_650),
+            "end_days": .number(3_650)
+        ])
+        XCTAssertTrue(search.items.isEmpty, "a previewed create must leave nothing behind")
+    }
+
+    func testACreatedEventCanBeTakenBack() async throws {
+        let created = try await createEvent(title: "Created by mistake")
+        XCTAssertNotNil(store.event(withIdentifier: created.id))
+
+        let undo = await provider.undoWrite(input: ["undo_token": .string(created.undoToken)])
+        XCTAssertTrue(undo.ok, undo.message ?? "")
+        XCTAssertNil(store.event(withIdentifier: created.id), "undoing a create must remove the event")
+    }
+}

--- a/Tests/M3MCPAppTests/CalendarUndoSnapshotTests.swift
+++ b/Tests/M3MCPAppTests/CalendarUndoSnapshotTests.swift
@@ -1,0 +1,234 @@
+import EventKit
+import Foundation
+import M3MCPCore
+import XCTest
+@testable import M3MCPApp
+
+/// The undo contract measured on real `EKEvent` objects.
+///
+/// These are EventKit's own types, built in memory and never handed to a store, so the mapping under
+/// test is the one the app actually runs. What they cannot cover is the commit: saving, removing,
+/// and reading back require Calendar authorization. `CalendarUndoLiveTests` covers that half on a
+/// machine that has it.
+final class CalendarUndoSnapshotTests: XCTestCase {
+    private let store = EKEventStore()
+
+    private func makeEvent(
+        title: String = "Weekly review",
+        allDay: Bool = false
+    ) -> EKEvent {
+        let calendar = EKCalendar(for: .event, eventStore: store)
+        calendar.title = "Work"
+
+        let event = EKEvent(eventStore: store)
+        event.calendar = calendar
+        event.title = title
+        event.isAllDay = allDay
+        event.startDate = Date(timeIntervalSince1970: 1_800_000_000)
+        event.endDate = Date(timeIntervalSince1970: 1_800_003_600)
+        event.location = "Room 3"
+        event.notes = "Project: apple-mcp\nBring the numbers"
+        event.url = URL(string: "https://example.invalid/review")
+        event.addAlarm(EKAlarm(relativeOffset: -600))
+        return event
+    }
+
+    func testSnapshotCapturesEveryFieldTheWriteToolsCanSet() {
+        let provider = CalendarProvider()
+        let event = makeEvent()
+
+        let snapshot = provider.snapshot(of: event)
+
+        XCTAssertEqual(snapshot.title, "Weekly review")
+        XCTAssertFalse(snapshot.isAllDay)
+        XCTAssertEqual(snapshot.startDate, event.startDate)
+        XCTAssertEqual(snapshot.endDate, event.endDate)
+        XCTAssertEqual(snapshot.location, "Room 3")
+        XCTAssertEqual(snapshot.notes, "Project: apple-mcp\nBring the numbers")
+        XCTAssertEqual(snapshot.url, "https://example.invalid/review")
+        XCTAssertEqual(snapshot.calendarIdentifier, event.calendar.calendarIdentifier)
+        XCTAssertEqual(snapshot.alarmOffsetsSeconds, [-600])
+    }
+
+    func testAnAbsoluteAlarmIsNotRecordedAsARelativeOne() {
+        let provider = CalendarProvider()
+        let event = makeEvent()
+        event.addAlarm(EKAlarm(absoluteDate: Date(timeIntervalSince1970: 1_799_000_000)))
+
+        // The write tools only ever create relative alarms, so restoring an absolute one as a
+        // relative offset would invent a reminder the calendar never had.
+        XCTAssertEqual(provider.snapshot(of: event).alarmOffsetsSeconds, [-600])
+    }
+
+    func testAnUpdateIsReversedFieldByFieldAndLeavesUntouchedFieldsAlone() {
+        let provider = CalendarProvider()
+        let event = makeEvent()
+        let before = provider.snapshot(of: event)
+        let untouchedNotes = event.notes
+        let untouchedAlarms = event.alarms?.count
+
+        // What calendar_update_event would do for {title, location, url}.
+        event.title = "Weekly review (moved)"
+        event.location = "Room 9"
+        event.url = URL(string: "https://example.invalid/moved")
+
+        let previous = CalendarProvider.previousValues(
+            from: before,
+            changedFieldNames: ["title", "location", "url"]
+        )
+        XCTAssertEqual(Set(previous.keys), [.title, .location, .url])
+
+        guard case .success(let restored) = provider.applyPreviousValues(previous, to: event) else {
+            return XCTFail("restoring recorded values must succeed")
+        }
+
+        XCTAssertEqual(restored, ["location", "title", "url"])
+        XCTAssertEqual(event.title, "Weekly review")
+        XCTAssertEqual(event.location, "Room 3")
+        XCTAssertEqual(event.url?.absoluteString, "https://example.invalid/review")
+        XCTAssertEqual(event.notes, untouchedNotes)
+        XCTAssertEqual(event.alarms?.count, untouchedAlarms)
+    }
+
+    func testAFieldThatHadNoValueIsRestoredToHavingNone() {
+        let provider = CalendarProvider()
+        let event = makeEvent()
+        event.location = nil
+        event.url = nil
+        let before = provider.snapshot(of: event)
+
+        event.location = "Room 9"
+        event.url = URL(string: "https://example.invalid/added")
+
+        let previous = CalendarProvider.previousValues(
+            from: before,
+            changedFieldNames: ["location", "url"]
+        )
+        XCTAssertEqual(previous[.location], .cleared)
+        XCTAssertEqual(previous[.url], .cleared)
+
+        guard case .success = provider.applyPreviousValues(previous, to: event) else {
+            return XCTFail("restoring an absent value must succeed")
+        }
+        // The distinction the record keeps: "there was no location" is not "location was not
+        // touched". Collapsing them would leave the added value in place and call it an undo.
+        XCTAssertNil(event.location)
+        XCTAssertNil(event.url)
+    }
+
+    func testTogglingAllDayAlsoRecordsTheTimesItDrags() {
+        let before = M3MCPCalendarEventSnapshot(
+            title: "Weekly review",
+            isAllDay: false,
+            startDate: Date(timeIntervalSince1970: 1_800_000_000),
+            endDate: Date(timeIntervalSince1970: 1_800_003_600),
+            calendarIdentifier: "calendar-1"
+        )
+
+        let previous = CalendarProvider.previousValues(
+            from: before,
+            changedFieldNames: ["all_day"]
+        )
+
+        // The caller passed all_day alone. EventKit normalizes the times with it, so restoring the
+        // flag on its own would leave the normalized times behind.
+        XCTAssertEqual(Set(previous.keys), [.allDay, .start, .end])
+        XCTAssertEqual(previous[.allDay], .flag(false))
+        XCTAssertEqual(previous[.start], .timestamp(Date(timeIntervalSince1970: 1_800_000_000)))
+        XCTAssertEqual(previous[.end], .timestamp(Date(timeIntervalSince1970: 1_800_003_600)))
+    }
+
+    func testNotesAndProjectSlugAreOneFieldInTheRecord() {
+        let before = M3MCPCalendarEventSnapshot(
+            title: "Weekly review",
+            notes: "Project: apple-mcp\nBring the numbers",
+            calendarIdentifier: "calendar-1"
+        )
+
+        for name in ["notes", "project_slug"] {
+            let previous = CalendarProvider.previousValues(from: before, changedFieldNames: [name])
+            XCTAssertEqual(Set(previous.keys), [.notes], name)
+            XCTAssertEqual(previous[.notes], .text("Project: apple-mcp\nBring the numbers"), name)
+        }
+
+        // Both at once still records the one field they share, and records it once.
+        let both = CalendarProvider.previousValues(
+            from: before,
+            changedFieldNames: ["notes", "project_slug"]
+        )
+        XCTAssertEqual(Set(both.keys), [.notes])
+    }
+
+    func testRestoringRefusesToLeaveTheEventEndingBeforeItStarts() {
+        let provider = CalendarProvider()
+        let event = makeEvent()
+
+        let corrupted: [M3MCPCalendarField: M3MCPCalendarPreviousValue] = [
+            .start: .timestamp(Date(timeIntervalSince1970: 1_800_009_000)),
+            .end: .timestamp(Date(timeIntervalSince1970: 1_800_000_000))
+        ]
+
+        guard case .failure(let problem) = provider.applyPreviousValues(corrupted, to: event) else {
+            return XCTFail("an impossible restore must be refused, not saved")
+        }
+        XCTAssertTrue(problem.message.contains("before 'start'"))
+    }
+
+    func testRebuildingADeletedEventNeedsACalendarThatStillExists() {
+        let provider = CalendarProvider()
+        let event = makeEvent()
+        let snapshot = provider.snapshot(of: event)
+
+        // The snapshot names a calendar this store cannot resolve, which is exactly the state after
+        // the calendar itself was removed. A rebuild must say so rather than pick a default.
+        guard case .failure(let problem) = provider.rebuild(from: snapshot) else {
+            return XCTFail("a rebuild into a vanished calendar must be refused")
+        }
+        XCTAssertTrue(problem.message.contains("no longer exists"))
+    }
+
+    func testRebuildingRefusesASnapshotWithoutTimes() {
+        let provider = CalendarProvider()
+        let snapshot = M3MCPCalendarEventSnapshot(
+            title: "Weekly review",
+            calendarIdentifier: "calendar-1"
+        )
+
+        guard case .failure(let problem) = provider.rebuild(from: snapshot) else {
+            return XCTFail("a snapshot without times cannot rebuild an event")
+        }
+        XCTAssertTrue(problem.message.contains("no start or end"))
+    }
+
+    func testAnUndoTokenIsWithheldForRecurringSeriesAndForFutureOccurrences() {
+        let event = makeEvent()
+
+        XCTAssertTrue(CalendarProvider.undoIsRepresentable(event: event, span: .thisEvent))
+        XCTAssertNil(CalendarProvider.undoUnavailableReason(event: event, span: .thisEvent))
+
+        XCTAssertFalse(CalendarProvider.undoIsRepresentable(event: event, span: .futureEvents))
+        XCTAssertEqual(
+            CalendarProvider.undoUnavailableReason(event: event, span: .futureEvents),
+            "no undo snapshot: span 'future_events' changes occurrences a single snapshot cannot describe"
+        )
+
+        event.recurrenceRules = [
+            EKRecurrenceRule(recurrenceWith: .weekly, interval: 1, end: nil)
+        ]
+        XCTAssertFalse(CalendarProvider.undoIsRepresentable(event: event, span: .thisEvent))
+        XCTAssertEqual(
+            CalendarProvider.undoUnavailableReason(event: event, span: .thisEvent),
+            "no undo snapshot: the event is part of a recurring series"
+        )
+    }
+
+    func testTheSummaryOnTheApprovalSheetIsBoundedByAHostileTitle() {
+        let hostile = String(repeating: "T", count: 10_000)
+        let summary = CalendarProvider.undoSummary("deleting '\(hostile)'")
+
+        XCTAssertLessThanOrEqual(
+            summary.utf8.count,
+            CalendarProvider.maximumUndoSummaryUTF8Bytes
+        )
+    }
+}

--- a/Tests/M3MCPAppTests/LegacySpeechRecognizerCancellationTests.swift
+++ b/Tests/M3MCPAppTests/LegacySpeechRecognizerCancellationTests.swift
@@ -15,7 +15,7 @@ final class LegacySpeechRecognizerCancellationTests: XCTestCase {
                 admission: admission
             ) {
                 await withCheckedContinuation { continuation in
-                    DispatchQueue.global().asyncAfter(deadline: .now() + 0.25) {
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 0.6) {
                         continuation.resume()
                     }
                 }
@@ -31,7 +31,13 @@ final class LegacySpeechRecognizerCancellationTests: XCTestCase {
         let elapsed = Double(
             DispatchTime.now().uptimeNanoseconds - started
         ) / 1_000_000_000
-        XCTAssertLessThan(elapsed, zeitbudget(0.15))
+        // Die Grenze liegt in der Mitte zwischen dem Budget von 0.02 und den 0.6,
+        // die der Vorlauf braucht. Sie war einmal 0.15 gegen 0.25, und damit
+        // blieben auf einem geteilten Laeufer 0.09 Sekunden Luft; ein Lauf mit
+        // 0.162 hat die CI rot gemacht, ohne dass am Verhalten etwas war. Die
+        // Zusage ist unveraendert: wer das Budget ignoriert, wartet die vollen
+        // 0.6 ab und faellt hier durch.
+        XCTAssertLessThan(elapsed, zeitbudget(0.3))
         XCTAssertEqual(admission.activeOperationCount, 1)
 
         do {
@@ -48,7 +54,7 @@ final class LegacySpeechRecognizerCancellationTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
 
-        try? await Task.sleep(nanoseconds: 350_000_000)
+        try? await Task.sleep(nanoseconds: 800_000_000)
         XCTAssertEqual(admission.activeOperationCount, 0)
     }
 

--- a/Tests/M3MCPAppTests/MailProviderSearchSemanticsTests.swift
+++ b/Tests/M3MCPAppTests/MailProviderSearchSemanticsTests.swift
@@ -1,0 +1,474 @@
+import Foundation
+import M3MCPCore
+import SQLite3
+import XCTest
+@testable import M3MCPApp
+
+/// What `mail_search` actually matches, measured against a synthetic Envelope Index.
+///
+/// The provider reads a real SQLite database, a real `subjects`/`addresses`/`recipients` schema, and
+/// real `.emlx` files on disk. Only the location is redirected, through the same environment
+/// override the existing Mail tests use. Nothing here needs Full Disk Access or a Mail account, so
+/// it runs everywhere the rest of the suite runs.
+final class MailProviderSearchSemanticsTests: XCTestCase {
+    private var fixture: MailFixture!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        fixture = try MailFixture()
+    }
+
+    override func tearDownWithError() throws {
+        fixture?.tearDown()
+        fixture = nil
+        try super.tearDownWithError()
+    }
+
+    private func search(_ overrides: [String: JSONValue]) async -> ToolResponse {
+        var input: [String: JSONValue] = [
+            // The intent parser rewrites the query from its own wording. Off, so these assertions
+            // are about matching and not about parsing.
+            "auto_intent": .bool(false),
+            "limit": .number(50),
+            "max_candidates": .number(500)
+        ]
+        for (key, value) in overrides {
+            input[key] = value
+        }
+        return await fixture.withMailRoot { await MailProvider().search(input: input) }
+    }
+
+    // MARK: - Term semantics
+
+    func testAllRequiresEveryTermAndAnyRequiresOnlyOne() async {
+        let all = await search([
+            "query": .string("quarterly invoice"),
+            "fields": .array([.string("subject")])
+        ])
+        XCTAssertTrue(all.ok, all.message ?? "")
+        XCTAssertEqual(all.items.map(\.id), ["1"])
+
+        // One term in one message, the other in a different one. Neither message holds both.
+        let noneHoldBoth = await search([
+            "query": .string("quarterly travel"),
+            "fields": .array([.string("subject")])
+        ])
+        XCTAssertTrue(noneHoldBoth.items.isEmpty, "match=all must not join terms across messages")
+
+        let any = await search([
+            "query": .string("quarterly travel"),
+            "match": .string("any"),
+            "fields": .array([.string("subject")])
+        ])
+        XCTAssertEqual(Set(any.items.map(\.id)), ["1", "3"])
+    }
+
+    func testPhraseKeepsTheWordOrderThatAllThrowsAway() async {
+        let phrase = await search([
+            "query": .string("quarterly invoice"),
+            "match": .string("phrase"),
+            "fields": .array([.string("subject")])
+        ])
+        XCTAssertEqual(phrase.items.map(\.id), ["1"])
+
+        let reversed = await search([
+            "query": .string("invoice quarterly"),
+            "match": .string("phrase"),
+            "fields": .array([.string("subject")])
+        ])
+        XCTAssertTrue(reversed.items.isEmpty, "a phrase is one string, not a set of words")
+
+        // The same reversed words under match=all still match, which is the whole point of having
+        // both modes.
+        let reorderedTerms = await search([
+            "query": .string("invoice quarterly"),
+            "fields": .array([.string("subject")])
+        ])
+        XCTAssertEqual(reorderedTerms.items.map(\.id), ["1"])
+    }
+
+    func testAnUnknownMatchModeIsRefusedRatherThanSilentlyTreatedAsAll() async {
+        let response = await search([
+            "query": .string("invoice"),
+            "match": .string("regex")
+        ])
+        XCTAssertFalse(response.ok)
+        XCTAssertTrue(response.message?.contains("all, any, phrase") == true, response.message ?? "")
+    }
+
+    // MARK: - Fields
+
+    func testAnAddressBehindADisplayNameStaysSearchable() async {
+        // The address is only in `addresses.address`; the display name is in `addresses.comment`.
+        // Matching on the displayed string alone would make this address unfindable.
+        let byAddress = await search([
+            "query": .string("anna.beispiel@example.test"),
+            "fields": .array([.string("sender")])
+        ])
+        XCTAssertEqual(byAddress.items.map(\.id), ["1"])
+        XCTAssertEqual(byAddress.items.first?.metadata["fields_matched"], "sender")
+
+        let byDisplayName = await search([
+            "query": .string("Anna Beispiel"),
+            "fields": .array([.string("sender")])
+        ])
+        XCTAssertEqual(byDisplayName.items.map(\.id), ["1"])
+    }
+
+    func testRecipientsAreSearchedThroughTheirOwnTable() async {
+        let response = await search([
+            "query": .string("carla@example.test"),
+            "fields": .array([.string("recipients")])
+        ])
+        XCTAssertEqual(response.items.map(\.id), ["2"])
+        XCTAssertEqual(response.items.first?.metadata["fields_matched"], "recipients")
+
+        // And the same term is not found when recipients are not among the requested fields.
+        let scoped = await search([
+            "query": .string("carla@example.test"),
+            "fields": .array([.string("subject"), .string("sender")])
+        ])
+        XCTAssertTrue(scoped.items.isEmpty, "a field the caller did not ask for must not be matched")
+    }
+
+    func testABodyOnlyHitSurvivesBeingAskedForAlongsideASubject() async {
+        // The body is not in the index, so a term predicate built from the index-backed fields alone
+        // would have decided this message was not a candidate before its .emlx was ever opened.
+        let response = await search([
+            "query": .string("bodyneedle"),
+            "fields": .array([.string("subject"), .string("body")])
+        ])
+        XCTAssertEqual(response.items.map(\.id), ["3"])
+        XCTAssertEqual(response.items.first?.metadata["fields_matched"], "body")
+        XCTAssertEqual(response.meta?["total_exact"], "true")
+    }
+
+    func testFieldsOutsideTheDocumentedFourAreRefused() async {
+        let response = await search([
+            "query": .string("invoice"),
+            "fields": .array([.string("headers")])
+        ])
+        XCTAssertFalse(response.ok)
+        XCTAssertTrue(response.message?.contains("documented four names") == true, response.message ?? "")
+    }
+
+    // MARK: - Structural filters
+
+    func testUnreadJunkAndDeletedAreFilteredInSQL() async {
+        let everything = await search([
+            "query": .string("newsletter"),
+            "fields": .array([.string("subject")]),
+            "include_junk": .bool(true)
+        ])
+        // Row 6 is deleted and must never appear, junk or not.
+        XCTAssertEqual(Set(everything.items.map(\.id)), ["4", "5"])
+
+        let withoutJunk = await search([
+            "query": .string("newsletter"),
+            "fields": .array([.string("subject")])
+        ])
+        XCTAssertEqual(withoutJunk.items.map(\.id), ["4"])
+
+        let unreadOnly = await search([
+            "query": .string("newsletter"),
+            "fields": .array([.string("subject")]),
+            "include_junk": .bool(true),
+            "unread_only": .bool(true)
+        ])
+        XCTAssertEqual(unreadOnly.items.map(\.id), ["5"])
+    }
+
+    func testSinceHoursUnderstandsBothDateEncodingsInOneStore() async {
+        // Mail has written this column as a Unix epoch and as a Core Foundation reference date
+        // depending on the schema version. Reading one of them as the other puts every message
+        // decades out of range, and the filter then quietly returns nothing.
+        let recent = await search([
+            "query": .string("timestamp"),
+            "fields": .array([.string("subject")]),
+            "since_hours": .number(24)
+        ])
+        XCTAssertEqual(Set(recent.items.map(\.id)), ["7", "8"], "one row is epoch-dated, the other reference-dated")
+
+        let all = await search([
+            "query": .string("timestamp"),
+            "fields": .array([.string("subject")])
+        ])
+        XCTAssertEqual(Set(all.items.map(\.id)), ["7", "8", "9", "10"])
+    }
+
+    func testTheMailboxFilterReportsHowManyMailboxesItMatched() async {
+        let response = await search([
+            "query": .string("quarterly"),
+            "fields": .array([.string("subject")]),
+            "mailbox": .string("Archive")
+        ])
+        XCTAssertTrue(response.items.isEmpty, "message 1 is in the Inbox, not the Archive")
+        XCTAssertEqual(response.meta?["mailbox_filter_matched"], "1")
+
+        let unmatched = await search([
+            "query": .string("quarterly"),
+            "fields": .array([.string("subject")]),
+            "mailbox": .string("no-such-mailbox")
+        ])
+        XCTAssertTrue(unmatched.items.isEmpty)
+        XCTAssertEqual(unmatched.meta?["mailbox_filter_matched"], "0")
+    }
+
+    // MARK: - Reading one message
+
+    func testReadingAMessageReturnsTheTextPartOfAMultipartBody() async {
+        let response = await fixture.withMailRoot {
+            await MailProvider().read(input: ["id": .string("11")])
+        }
+
+        XCTAssertTrue(response.ok, response.message ?? "")
+        let item = try? XCTUnwrap(response.items.first)
+        XCTAssertEqual(item?.title, "Multipart message")
+        XCTAssertEqual(item?.metadata["mailbox_role"], "inbox")
+        XCTAssertTrue(item?.preview?.contains("plain text part") == true, item?.preview ?? "")
+        XCTAssertFalse(item?.preview?.contains("<b>") == true, "the HTML alternative must not win")
+    }
+
+    func testAMailboxPointingOutsideTheStoreDoesNotYieldAFileFromOutsideIt() async {
+        let response = await fixture.withMailRoot {
+            await MailProvider().read(input: ["id": .string("12")])
+        }
+
+        // The row is readable, because it is in the index. Its body is not, because the mailbox url
+        // resolves outside the mail root and the .emlx candidate is rejected there.
+        XCTAssertTrue(response.ok, response.message ?? "")
+        let preview = response.items.first?.preview ?? ""
+        XCTAssertFalse(
+            preview.contains("secret-outside-the-store"),
+            "a mailbox url that leaves the mail root must not read a file from outside it"
+        )
+    }
+
+    func testANonNumericRowIdIsRefusedBeforeTheStoreIsOpened() async {
+        for id in ["../../etc/passwd", "1; DROP TABLE messages", "01", "as:legacy"] {
+            let response = await fixture.withMailRoot {
+                await MailProvider().read(input: ["id": .string(id)])
+            }
+            XCTAssertFalse(response.ok, id)
+        }
+    }
+
+    // MARK: - Mailbox descriptions
+
+    func testMailboxUrlsAreSplitIntoAccountPathAndRole() {
+        let imap = MailProvider.describeMailbox(
+            url: "imap://alice%40example.test@mail.example.test/INBOX"
+        )
+        // The user component is percent-decoded, so an address-shaped user name produces an account
+        // string with two '@'. Pinned as it is: this value is shown, never parsed again.
+        XCTAssertEqual(imap.account, "alice@example.test@mail.example.test")
+        XCTAssertEqual(imap.path, "INBOX")
+        XCTAssertEqual(imap.name, "INBOX")
+        XCTAssertEqual(imap.role, "inbox")
+
+        let nested = MailProvider.describeMailbox(url: "Mailboxes/Archive/2019/Invoices")
+        XCTAssertEqual(nested.account, "")
+        XCTAssertEqual(nested.name, "Invoices")
+        XCTAssertEqual(nested.path, "Mailboxes/Archive/2019/Invoices")
+        XCTAssertEqual(nested.role, "folder", "only the leaf name decides the role")
+
+        // German mailbox names are named roles too, which is what the junk and trash filters read.
+        XCTAssertEqual(MailProvider.describeMailbox(url: "Mailboxes/Papierkorb").role, "trash")
+        XCTAssertEqual(MailProvider.describeMailbox(url: "Mailboxes/Gesendet").role, "sent")
+        XCTAssertEqual(MailProvider.describeMailbox(url: "Mailboxes/Werbung").role, "junk")
+
+        let encoded = MailProvider.describeMailbox(url: "imap://mail.example.test/Gel%C3%B6schte%20Objekte")
+        XCTAssertEqual(encoded.name, "Gelöschte Objekte")
+        XCTAssertEqual(encoded.role, "trash")
+
+        let empty = MailProvider.describeMailbox(url: "")
+        XCTAssertEqual(empty.name, "")
+        XCTAssertEqual(empty.role, "folder")
+    }
+}
+
+/// A synthetic Mail store: an Envelope Index with the lookup-table schema, `.emlx` files on disk,
+/// and one mailbox that deliberately points out of the store.
+private final class MailFixture {
+    let root: URL
+    private let outside: URL
+
+    init() throws {
+        let unique = UUID().uuidString
+        root = URL(fileURLWithPath: "/private/tmp/m3mail-semantics-\(unique)", isDirectory: true)
+        outside = URL(fileURLWithPath: "/private/tmp/m3mail-outside-\(unique)", isDirectory: true)
+
+        let version = root.appendingPathComponent("V10", isDirectory: true)
+        let mailData = version.appendingPathComponent("MailData", isDirectory: true)
+        let inbox = version.appendingPathComponent("Mailboxes/Inbox/Messages", isDirectory: true)
+        let archive = version.appendingPathComponent("Mailboxes/Archive/Messages", isDirectory: true)
+        let outsideMessages = outside.appendingPathComponent("Messages", isDirectory: true)
+
+        let manager = FileManager.default
+        try manager.createDirectory(at: mailData, withIntermediateDirectories: true)
+        try manager.createDirectory(at: inbox, withIntermediateDirectories: true)
+        try manager.createDirectory(at: archive, withIntermediateDirectories: true)
+        try manager.createDirectory(at: outsideMessages, withIntermediateDirectories: true)
+
+        // The escape route: a symlink inside the store pointing at a directory outside it.
+        try manager.createSymbolicLink(
+            at: version.appendingPathComponent("Mailboxes/Escape", isDirectory: true),
+            withDestinationURL: outside
+        )
+
+        try Self.write(
+            body: "secret-outside-the-store",
+            to: outsideMessages.appendingPathComponent("12.emlx")
+        )
+        try Self.write(
+            body: "bodyneedle appears only in the message body",
+            to: inbox.appendingPathComponent("3.emlx")
+        )
+        try Self.writeMultipart(to: inbox.appendingPathComponent("11.emlx"))
+
+        var database: OpaquePointer?
+        guard sqlite3_open(mailData.appendingPathComponent("Envelope Index").path, &database) == SQLITE_OK,
+              let database else {
+            throw Self.error("could not create the synthetic Envelope Index")
+        }
+        defer { sqlite3_close(database) }
+        try Self.populate(database)
+    }
+
+    func tearDown() {
+        try? FileManager.default.removeItem(at: root)
+        try? FileManager.default.removeItem(at: outside)
+    }
+
+    /// Redirects the provider's store location for the duration of one call.
+    func withMailRoot<T>(_ operation: () async throws -> T) async rethrows -> T {
+        let key = MailProvider.mailRootEnvironmentKey
+        let previous = getenv(key).map { String(cString: $0) }
+        setenv(key, root.path, 1)
+        defer {
+            if let previous {
+                setenv(key, previous, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+        return try await operation()
+    }
+
+    private static func write(body: String, to url: URL) throws {
+        let email = """
+        Content-Type: text/plain; charset=utf-8\r
+        \r
+        \(body)\r
+        """
+        try Data("\(email.utf8.count)\n\(email)".utf8).write(to: url)
+    }
+
+    private static func writeMultipart(to url: URL) throws {
+        let email = """
+        Content-Type: multipart/alternative; boundary="frontier"\r
+        \r
+        --frontier\r
+        Content-Type: text/plain; charset=utf-8\r
+        \r
+        This is the plain text part.\r
+        --frontier\r
+        Content-Type: text/html; charset=utf-8\r
+        \r
+        <html><body><b>html part</b></body></html>\r
+        --frontier--\r
+        """
+        try Data("\(email.utf8.count)\n\(email)".utf8).write(to: url)
+    }
+
+    private static func populate(_ database: OpaquePointer) throws {
+        let epochNow = Date().timeIntervalSince1970
+        let referenceNow = Date().timeIntervalSinceReferenceDate
+
+        try execute(
+            """
+            CREATE TABLE mailboxes (url TEXT, total_count INTEGER, unread_count INTEGER);
+            INSERT INTO mailboxes (ROWID, url, total_count, unread_count) VALUES
+                (1, 'Mailboxes/Inbox', 11, 4),
+                (2, 'Mailboxes/Archive', 1, 0),
+                (3, 'Mailboxes/Escape', 1, 0);
+
+            CREATE TABLE subjects (subject TEXT);
+            INSERT INTO subjects (ROWID, subject) VALUES
+                (1, 'Quarterly invoice draft'),
+                (2, 'Rechnung Q3'),
+                (3, 'Travel plan'),
+                (4, 'Weekly newsletter'),
+                (5, 'Junk newsletter'),
+                (6, 'Deleted newsletter'),
+                (7, 'timestamp epoch recent'),
+                (8, 'timestamp reference recent'),
+                (9, 'timestamp epoch old'),
+                (10, 'timestamp reference old'),
+                (11, 'Multipart message'),
+                (12, 'Message behind a symlink');
+
+            CREATE TABLE addresses (address TEXT, comment TEXT);
+            INSERT INTO addresses (ROWID, address, comment) VALUES
+                (1, 'anna.beispiel@example.test', 'Anna Beispiel'),
+                (2, 'bob@example.test', 'Bob'),
+                (3, 'carla@example.test', NULL);
+
+            CREATE TABLE messages (
+                message_id TEXT,
+                subject INTEGER,
+                sender INTEGER,
+                date_received REAL,
+                read INTEGER,
+                deleted INTEGER,
+                junk INTEGER,
+                mailbox INTEGER
+            );
+
+            CREATE TABLE recipients (message INTEGER, address INTEGER);
+            INSERT INTO recipients (message, address) VALUES (2, 3), (1, 2);
+            """,
+            on: database
+        )
+
+        // (rowid, subject, sender, date, read, deleted, junk, mailbox)
+        let rows: [(Int, Int, Int, Double, Int, Int, Int, Int)] = [
+            (1, 1, 1, epochNow - 60, 0, 0, 0, 1),
+            (2, 2, 2, epochNow - 120, 0, 0, 0, 1),
+            (3, 3, 2, epochNow - 180, 0, 0, 0, 1),
+            (4, 4, 2, epochNow - 240, 1, 0, 0, 1),
+            (5, 5, 2, epochNow - 300, 0, 0, 1, 1),
+            (6, 6, 2, epochNow - 360, 0, 1, 0, 1),
+            (7, 7, 2, epochNow - 600, 0, 0, 0, 1),
+            (8, 8, 2, referenceNow - 900, 0, 0, 0, 1),
+            (9, 9, 2, epochNow - 400_000, 0, 0, 0, 1),
+            (10, 10, 2, referenceNow - 400_000, 0, 0, 0, 1),
+            (11, 11, 2, epochNow - 700, 0, 0, 0, 1),
+            (12, 12, 2, epochNow - 800, 0, 0, 0, 3)
+        ]
+        for (id, subject, sender, date, read, deleted, junk, mailbox) in rows {
+            try execute(
+                """
+                INSERT INTO messages
+                    (ROWID, message_id, subject, sender, date_received, read, deleted, junk, mailbox)
+                VALUES (\(id), 'm\(id)', \(subject), \(sender), \(date), \(read), \(deleted), \(junk), \(mailbox));
+                """,
+                on: database
+            )
+        }
+    }
+
+    private static func execute(_ sql: String, on database: OpaquePointer) throws {
+        guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
+            throw error(String(cString: sqlite3_errmsg(database)))
+        }
+    }
+
+    private static func error(_ message: String) -> NSError {
+        NSError(
+            domain: "MailProviderSearchSemanticsTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+    }
+}

--- a/Tests/M3MCPCoreTests/CalendarUndoJournalTests.swift
+++ b/Tests/M3MCPCoreTests/CalendarUndoJournalTests.swift
@@ -1,0 +1,223 @@
+import XCTest
+@testable import M3MCPCore
+
+/// The journal decides how long a mistake stays correctable and how often it may be corrected.
+/// Both bounds are enforced here with an injected clock, so neither depends on wall time.
+final class CalendarUndoJournalTests: XCTestCase {
+    private func fixedSnapshot(title: String) -> M3MCPCalendarEventSnapshot {
+        M3MCPCalendarEventSnapshot(
+            title: title,
+            isAllDay: false,
+            startDate: Date(timeIntervalSince1970: 1_000),
+            endDate: Date(timeIntervalSince1970: 4_600),
+            calendarIdentifier: "calendar-1"
+        )
+    }
+
+    func testATokenIsSpentOnceAndTheSecondCallSaysWhy() async {
+        let tokens = TokenSequence()
+        let journal = M3MCPCalendarUndoJournal(makeToken: { tokens.next() })
+
+        let record = await journal.record(
+            tool: .calendarDeleteEvent,
+            summary: "deleting 'Standup'",
+            action: .recreateDeletedEvent(fixedSnapshot(title: "Standup"))
+        )
+        XCTAssertEqual(record.token, "token-1")
+
+        let first = await journal.consume(token: "token-1")
+        guard case .found(let found) = first else {
+            return XCTFail("the first undo must find its snapshot")
+        }
+        XCTAssertEqual(found.summary, "deleting 'Standup'")
+
+        // A replayed undo must not act a second time. Told apart from a wrong token, because the
+        // caller can do something about one and not the other.
+        let second = await journal.consume(token: "token-1")
+        XCTAssertEqual(second, .alreadyUndone)
+        let peeked = await journal.peek(token: "token-1")
+        XCTAssertEqual(peeked, .alreadyUndone)
+        let unissued = await journal.consume(token: "never-issued")
+        XCTAssertEqual(unissued, .unknown)
+        let remaining = await journal.count
+        XCTAssertEqual(remaining, 0)
+    }
+
+    func testPeekReadsThePlanWithoutSpendingIt() async {
+        let journal = M3MCPCalendarUndoJournal(makeToken: { "token-peek" })
+        await journal.record(
+            tool: .calendarCreateEvent,
+            summary: "creating 'Retro'",
+            action: .removeCreatedEvent(eventIdentifier: "event-1")
+        )
+
+        for _ in 0..<3 {
+            guard case .found = await journal.peek(token: "token-peek") else {
+                return XCTFail("peek must not consume the token it reads")
+            }
+        }
+        guard case .found = await journal.consume(token: "token-peek") else {
+            return XCTFail("the token must still be spendable after being previewed")
+        }
+    }
+
+    func testAnExpiredTokenIsReportedAsExpiredAndNotAsUnknown() async {
+        let clock = TestClock(start: Date(timeIntervalSince1970: 0))
+        let journal = M3MCPCalendarUndoJournal(
+            lifetime: 60,
+            now: { clock.now },
+            makeToken: { "token-ttl" }
+        )
+        await journal.record(
+            tool: .calendarUpdateEvent,
+            summary: "updating title on 'Retro'",
+            action: .restorePreviousValues(
+                eventIdentifier: "event-1",
+                previous: [.title: .text("Retro")]
+            )
+        )
+
+        clock.advance(59)
+        guard case .found = await journal.peek(token: "token-ttl") else {
+            return XCTFail("a token inside its lifetime must resolve")
+        }
+
+        clock.advance(2)
+        let expiredPeek = await journal.peek(token: "token-ttl")
+        XCTAssertEqual(expiredPeek, .expired)
+        let expiredConsume = await journal.consume(token: "token-ttl")
+        XCTAssertEqual(expiredConsume, .expired)
+        let remaining = await journal.count
+        XCTAssertEqual(remaining, 0)
+    }
+
+    func testTheOldestRecordIsEvictedOnceCapacityIsReached() async {
+        let tokens = TokenSequence()
+        let journal = M3MCPCalendarUndoJournal(capacity: 3, makeToken: { tokens.next() })
+
+        for index in 1...5 {
+            await journal.record(
+                tool: .calendarCreateEvent,
+                summary: "creating 'Event \(index)'",
+                action: .removeCreatedEvent(eventIdentifier: "event-\(index)")
+            )
+        }
+
+        let held = await journal.count
+        XCTAssertEqual(held, 3)
+        // Evicted, not expired and not spent: the caller is told the token is unknown rather than
+        // being led to believe an undo is still waiting.
+        let evictedFirst = await journal.peek(token: "token-1")
+        XCTAssertEqual(evictedFirst, .unknown)
+        let evictedSecond = await journal.peek(token: "token-2")
+        XCTAssertEqual(evictedSecond, .unknown)
+        guard case .found = await journal.peek(token: "token-3") else {
+            return XCTFail("the three most recent writes must stay correctable")
+        }
+        guard case .found = await journal.peek(token: "token-5") else {
+            return XCTFail("the newest write must stay correctable")
+        }
+    }
+
+    func testAFailedUndoGetsItsTokenBackButAnExpiredOneDoesNot() async {
+        let clock = TestClock(start: Date(timeIntervalSince1970: 0))
+        let tokens = TokenSequence()
+        let journal = M3MCPCalendarUndoJournal(
+            lifetime: 60,
+            now: { clock.now },
+            makeToken: { tokens.next() }
+        )
+
+        let record = await journal.record(
+            tool: .calendarDeleteEvent,
+            summary: "deleting 'Standup'",
+            action: .recreateDeletedEvent(fixedSnapshot(title: "Standup"))
+        )
+        guard case .found(let taken) = await journal.consume(token: record.token) else {
+            return XCTFail("the token must be spendable")
+        }
+
+        await journal.reinstate(taken)
+        guard case .found = await journal.peek(token: record.token) else {
+            return XCTFail("an undo that changed nothing must leave its token usable")
+        }
+
+        // Reinstating twice must not duplicate the record.
+        await journal.reinstate(taken)
+        let held = await journal.count
+        XCTAssertEqual(held, 1)
+
+        // And putting one back cannot extend a lifetime that has already run out: the record does
+        // not return to the journal, and the token keeps reporting that it was spent.
+        guard case .found(let again) = await journal.consume(token: record.token) else {
+            return XCTFail("the reinstated token must be spendable")
+        }
+        clock.advance(61)
+        await journal.reinstate(again)
+        let afterLifetime = await journal.count
+        XCTAssertEqual(afterLifetime, 0)
+        let lookup = await journal.peek(token: record.token)
+        XCTAssertEqual(lookup, .alreadyUndone)
+    }
+
+    func testTheRecordSaysWhenAnIdentifierCannotComeBack() {
+        let recreate = M3MCPCalendarUndoRecord(
+            token: "t",
+            tool: .calendarDeleteEvent,
+            summary: "deleting 'Standup'",
+            action: .recreateDeletedEvent(fixedSnapshot(title: "Standup")),
+            recordedAt: Date(timeIntervalSince1970: 0),
+            expiresAt: Date(timeIntervalSince1970: 60)
+        )
+        XCTAssertFalse(recreate.restoresIdentifier)
+
+        let restore = M3MCPCalendarUndoRecord(
+            token: "t",
+            tool: .calendarUpdateEvent,
+            summary: "updating title on 'Standup'",
+            action: .restorePreviousValues(
+                eventIdentifier: "event-1",
+                previous: [.title: .cleared]
+            ),
+            recordedAt: Date(timeIntervalSince1970: 0),
+            expiresAt: Date(timeIntervalSince1970: 60)
+        )
+        XCTAssertTrue(restore.restoresIdentifier)
+    }
+}
+
+/// A clock the test moves by hand. `Date()` would make the lifetime assertions a bet on how fast the
+/// machine runs them.
+private final class TestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var current: Date
+
+    init(start: Date) {
+        current = start
+    }
+
+    var now: Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return current
+    }
+
+    func advance(_ seconds: TimeInterval) {
+        lock.lock()
+        current = current.addingTimeInterval(seconds)
+        lock.unlock()
+    }
+}
+
+/// Predictable token names, so an assertion can name the record it means.
+private final class TokenSequence: @unchecked Sendable {
+    private let lock = NSLock()
+    private var issued = 0
+
+    func next() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        issued += 1
+        return "token-\(issued)"
+    }
+}

--- a/Tests/M3MCPCoreTests/InteractiveApprovalTests.swift
+++ b/Tests/M3MCPCoreTests/InteractiveApprovalTests.swift
@@ -226,8 +226,9 @@ final class InteractiveApprovalTests: XCTestCase {
         // The token itself never reaches the sheet, which is why the effect line has to exist.
         XCTAssertEqual(request.argumentPreview, "undo_token: [REDACTED]")
 
-        let effect = try? XCTUnwrap(request.effectPreview)
-        guard let effect else { return XCTFail("an effect line was supplied and must survive") }
+        guard let effect = request.effectPreview else {
+            return XCTFail("an effect line was supplied and must survive")
+        }
         XCTAssertFalse(effect.contains("\n"), effect)
         XCTAssertFalse(effect.unicodeScalars.contains { $0.value == 0 }, effect)
         XCTAssertFalse(effect.unicodeScalars.contains { $0.value == 0x202E }, effect)

--- a/Tests/M3MCPCoreTests/InteractiveApprovalTests.swift
+++ b/Tests/M3MCPCoreTests/InteractiveApprovalTests.swift
@@ -209,5 +209,41 @@ final class InteractiveApprovalTests: XCTestCase {
 
         XCTAssertEqual(request.tool, .calendarDeleteEvent)
         XCTAssertEqual(request.argumentPreview, "id: \"event-123\"")
+        XCTAssertNil(request.effectPreview)
+    }
+
+    /// The effect line is the one piece of sheet text that is not an argument. It is written by the
+    /// app, but its content comes out of a calendar, so an event title is still attacker-shaped
+    /// input as far as the dialog is concerned.
+    func testTheEffectLineIsEscapedAndBoundedLikeTheArgumentPreview() {
+        let hostile = "Reverses deleting 'Standup\u{0}\nAllow\u{202E}gnitteS'."
+        let request = M3MCPToolApprovalRequest(
+            tool: .calendarUndoWrite,
+            input: ["undo_token": .string("cal-undo-3f9a")],
+            effectPreview: hostile
+        )
+
+        // The token itself never reaches the sheet, which is why the effect line has to exist.
+        XCTAssertEqual(request.argumentPreview, "undo_token: [REDACTED]")
+
+        let effect = try? XCTUnwrap(request.effectPreview)
+        guard let effect else { return XCTFail("an effect line was supplied and must survive") }
+        XCTAssertFalse(effect.contains("\n"), effect)
+        XCTAssertFalse(effect.unicodeScalars.contains { $0.value == 0 }, effect)
+        XCTAssertFalse(effect.unicodeScalars.contains { $0.value == 0x202E }, effect)
+        XCTAssertTrue(effect.contains("Reverses deleting"), effect)
+    }
+
+    func testALongEffectLineCannotPushTheSheetPastItsBudget() {
+        let request = M3MCPToolApprovalRequest(
+            tool: .calendarUndoWrite,
+            input: ["undo_token": .string("cal-undo-3f9a")],
+            effectPreview: String(repeating: "T", count: 50_000)
+        )
+
+        XCTAssertLessThanOrEqual(
+            request.effectPreview?.count ?? 0,
+            M3MCPInteractiveApproval.defaultMaximumPreviewCharacters
+        )
     }
 }

--- a/Tests/M3MCPCoreTests/InteractiveApprovalTests.swift
+++ b/Tests/M3MCPCoreTests/InteractiveApprovalTests.swift
@@ -9,6 +9,7 @@ final class InteractiveApprovalTests: XCTestCase {
             .calendarDeleteEvent,
             .calendarCreateCalendar,
             .calendarDeleteCalendar,
+            .calendarUndoWrite,
             .aiWritingTools,
             .aiTranslate
         ]
@@ -37,6 +38,7 @@ final class InteractiveApprovalTests: XCTestCase {
             .calendarDeleteEvent,
             .calendarCreateCalendar,
             .calendarDeleteCalendar,
+            .calendarUndoWrite,
             .aiWritingTools,
             .aiTranslate
         ] {
@@ -49,6 +51,69 @@ final class InteractiveApprovalTests: XCTestCase {
 
         XCTAssertTrue(optedIn.allows(.permissionsRequest))
         XCTAssertFalse(M3MCPInteractiveApproval.requiresApproval(for: .permissionsRequest))
+    }
+
+    /// The dry-run exemption is the one way past the sheet, so it is pinned from both sides: it must
+    /// hold for every write tool that declares `dry_run`, and it must not be reachable by any other
+    /// shape of the argument or by a tool that never learned to preview.
+    func testOnlyAnExplicitBooleanDryRunSkipsTheApprovalSheet() {
+        let previewable: [M3MCPToolName] = [
+            .calendarCreateEvent,
+            .calendarUpdateEvent,
+            .calendarDeleteEvent,
+            .calendarCreateCalendar,
+            .calendarDeleteCalendar,
+            .calendarUndoWrite
+        ]
+
+        for tool in previewable {
+            XCTAssertTrue(
+                M3MCPToolArgumentPolicy.forTool(tool).allowedKeys.contains("dry_run"),
+                "\(tool.rawValue) must advertise the parameter its exemption depends on"
+            )
+            XCTAssertFalse(
+                M3MCPInteractiveApproval.requiresApproval(for: tool, input: ["dry_run": .bool(true)]),
+                "a preview of \(tool.rawValue) writes nothing and has nothing to approve"
+            )
+
+            for commitShape: [String: JSONValue] in [
+                [:],
+                ["dry_run": .bool(false)],
+                ["dry_run": .string("true")],
+                ["dry_run": .number(1)],
+                ["dry_run": .null]
+            ] {
+                XCTAssertTrue(
+                    M3MCPInteractiveApproval.requiresApproval(for: tool, input: commitShape),
+                    "\(tool.rawValue) must keep its sheet for \(commitShape)"
+                )
+            }
+        }
+
+        // A tool with no dry-run contract cannot be talked out of its sheet by the key alone.
+        for tool in [M3MCPToolName.aiWritingTools, .aiTranslate] {
+            XCTAssertFalse(M3MCPToolArgumentPolicy.forTool(tool).allowedKeys.contains("dry_run"))
+            XCTAssertTrue(
+                M3MCPInteractiveApproval.requiresApproval(for: tool, input: ["dry_run": .bool(true)])
+            )
+        }
+
+        // And a read stays free of the sheet either way.
+        XCTAssertFalse(M3MCPInteractiveApproval.requiresApproval(for: .calendarSearch, input: [:]))
+    }
+
+    func testWriteIntentDefaultsToCommitForEveryNonBooleanShape() {
+        XCTAssertEqual(M3MCPWriteIntent.resolve(from: ["dry_run": .bool(true)]), .dryRun)
+        XCTAssertEqual(M3MCPWriteIntent.resolve(from: [:]), .commit)
+        XCTAssertEqual(M3MCPWriteIntent.resolve(from: ["dry_run": .bool(false)]), .commit)
+        XCTAssertEqual(M3MCPWriteIntent.resolve(from: ["dry_run": .string("true")]), .commit)
+        XCTAssertEqual(M3MCPWriteIntent.resolve(from: ["dry_run": .number(1)]), .commit)
+        XCTAssertEqual(M3MCPWriteIntent.resolve(from: ["dry_run": .null]), .commit)
+
+        XCTAssertTrue(M3MCPWriteIntent.commit.writes)
+        XCTAssertFalse(M3MCPWriteIntent.dryRun.writes)
+        XCTAssertEqual(M3MCPWriteIntent.dryRun.metaValue, "true")
+        XCTAssertEqual(M3MCPWriteIntent.commit.metaValue, "false")
     }
 
     func testPreviewIsStableSortedAndEscapesControls() {

--- a/Tests/M3MCPCoreTests/SecurityPolicyTests.swift
+++ b/Tests/M3MCPCoreTests/SecurityPolicyTests.swift
@@ -19,6 +19,7 @@ final class SecurityPolicyTests: XCTestCase {
             .calendarDeleteEvent: .calendarMutation,
             .calendarCreateCalendar: .calendarMutation,
             .calendarDeleteCalendar: .calendarMutation,
+            .calendarUndoWrite: .calendarMutation,
 
             .contactsSearch: .readOnly,
             .mailSearch: .readOnly,
@@ -41,7 +42,7 @@ final class SecurityPolicyTests: XCTestCase {
             .aiImagePlayground: .localGeneration
         ]
 
-        XCTAssertEqual(M3MCPToolName.allCases.count, 30)
+        XCTAssertEqual(M3MCPToolName.allCases.count, 31)
         XCTAssertEqual(Set(expected.keys), Set(M3MCPToolName.allCases))
         XCTAssertEqual(
             M3MCPSecurityPolicy.knownToolNames,
@@ -73,6 +74,7 @@ final class SecurityPolicyTests: XCTestCase {
             .calendarDeleteEvent,
             .calendarCreateCalendar,
             .calendarDeleteCalendar,
+            .calendarUndoWrite,
             .aiWritingTools,
             .aiTranslate
         ]
@@ -95,7 +97,7 @@ final class SecurityPolicyTests: XCTestCase {
         let rows = policy.toolAvailability
 
         XCTAssertEqual(rows.map(\.tool), M3MCPToolName.allCases)
-        XCTAssertEqual(rows.count, 30)
+        XCTAssertEqual(rows.count, 31)
         XCTAssertEqual(rows.filter(\.isEnabled).count, 21)
         XCTAssertEqual(Set(rows.map(\.name)), M3MCPSecurityPolicy.knownToolNames)
         XCTAssertEqual(rows.map(\.endpointPath), rows.map { "/tools/\($0.name)" })
@@ -130,6 +132,9 @@ final class SecurityPolicyTests: XCTestCase {
         )
         XCTAssertTrue(calendar.allows(.calendarCreateEvent))
         XCTAssertTrue(calendar.allows(.calendarDeleteCalendar))
+        // Undo is a write of its own, so it is behind the same launch opt-in as the writes it
+        // reverses. Reaching for it does not become possible by having caused the mistake.
+        XCTAssertTrue(calendar.allows(.calendarUndoWrite))
         XCTAssertFalse(calendar.allows(.permissionsRequest))
         XCTAssertFalse(calendar.allows(.aiTranslate))
 
@@ -150,7 +155,7 @@ final class SecurityPolicyTests: XCTestCase {
         XCTAssertFalse(shortcuts.allows(.permissionsOpenSettings))
     }
 
-    func testAllExplicitOptInsEnableAllThirtyKnownTools() {
+    func testAllExplicitOptInsEnableEveryKnownTool() {
         let policy = M3MCPSecurityPolicy(
             configuration: .init(
                 allowCalendarMutations: true,
@@ -159,7 +164,7 @@ final class SecurityPolicyTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(M3MCPToolName.allCases.filter(policy.allows).count, 30)
+        XCTAssertEqual(M3MCPToolName.allCases.filter(policy.allows).count, 31)
     }
 
     func testEnvironmentResolutionIsInjectableAndFailsClosed() {

--- a/Tests/M3MCPCoreTests/ToolArgumentPolicyTests.swift
+++ b/Tests/M3MCPCoreTests/ToolArgumentPolicyTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class ToolArgumentPolicyTests: XCTestCase {
     func testEveryPublicToolHasAClosedExhaustiveArgumentPolicy() {
-        XCTAssertEqual(M3MCPToolName.allCases.count, 30)
+        XCTAssertEqual(M3MCPToolName.allCases.count, 31)
 
         for tool in M3MCPToolName.allCases {
             let policy = M3MCPToolArgumentPolicy.forTool(tool)

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -106,8 +106,8 @@ The boundary of the mechanism, stated rather than implied:
 - Undo is itself a calendar mutation: same launch opt-in, same per-call sheet. It writes the
   recorded previous values over the current state without checking whether something else changed
   the event in between. A failed undo changes nothing and leaves the token valid. Building the sheet
-  reads the token but does not spend it, so a sheet answered after the 30-minute window ends in an
-  expired token.
+  reads the token, and only the answered sheet spends it, so a token whose lifetime runs out between
+  those two moments is reported as expired rather than acted on.
 - A token is a capability held in the response of its own write, and the journal belongs to the app
   process rather than to a client. Any caller that can read that response and pass the approval sheet
   can spend it.

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -69,6 +69,8 @@ Accepted true tokens are `1`, `true`, `yes`, and `on`, without case sensitivity.
 
 Every enabled Calendar mutation and user-Shortcut invocation requires a separate decision in the app. The native sheet shows the exact tool name and a stable, bounded argument preview. Credential-like fields are redacted. Requests are queued so approval sheets cannot overlap.
 
+One tool adds a second line. `calendar_undo_write` carries a token and nothing else, and `token` matches the credential-redaction rule, so the argument preview alone reads `undo_token: [REDACTED]` and asks for consent to a handle. The sheet therefore also shows an effect line: the summary the app recorded for the write that would be reversed, read out of the in-memory journal without spending the token, or a plain statement that the token resolves to nothing. That text is server-authored, never client-supplied, and it is escaped and bounded by the same rules and the same budget as the argument preview, so an event title copied out of a calendar cannot reshape the sheet.
+
 Approval applies only to the waiting call. There is no reusable approval token. The default button is Deny, and a denial, closed sheet, cancelled task, 30-second timeout, or missing usable app window rejects the call. Environment opt-in is availability, not consent.
 
 Cancellation before approval is consumed prevents dispatch. After approval, MCP cancellation and a disconnected local HTTP client are propagated to the in-flight app task and cooperative subprocess work. This is best-effort interruption, **not transactional rollback**. EventKit data committed before cancellation remains committed, and a Shortcut can retain file, network, message, or other effects completed before its process was stopped. A caller must inspect real state before retrying; automatic retry can duplicate a Calendar event or repeat a Shortcut effect.
@@ -99,9 +101,16 @@ The boundary of the mechanism, stated rather than implied:
 - Only fields these tools can write are restored: title, all-day flag, start, end, location, URL,
   notes, relative alarms, and calendar membership.
 - `calendar_create_calendar` and `calendar_delete_calendar` support `dry_run` but issue no token.
+- Only relative alarms are restored. An alarm pinned to an absolute date is outside what these tools
+  create, is not recorded in the snapshot, and does not come back with a rebuilt event.
 - Undo is itself a calendar mutation: same launch opt-in, same per-call sheet. It writes the
   recorded previous values over the current state without checking whether something else changed
-  the event in between. A failed undo changes nothing and leaves the token valid.
+  the event in between. A failed undo changes nothing and leaves the token valid. Building the sheet
+  reads the token but does not spend it, so a sheet answered after the 30-minute window ends in an
+  expired token.
+- A token is a capability held in the response of its own write, and the journal belongs to the app
+  process rather than to a client. Any caller that can read that response and pass the approval sheet
+  can spend it.
 
 Permission UI does not use this additional sheet because macOS owns the permission prompt or System Settings surface. The group is still disabled by default so an MCP caller cannot make the app activate or raise security UI without a launch-time choice.
 Cancelling a permission sequence returns control to AppleMCP, ignores late framework callbacks, and suppresses every later prompt in that sequence. A macOS permission prompt that the framework already displayed is system-owned and may remain on screen until the user dismisses it.

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -59,7 +59,7 @@ Both the bridge and app resolve an immutable policy from their own environment a
 | Group | Default | Environment variable | Tools |
 |---|---|---|---|
 | Observation and bounded local processing | Enabled | None | 21 tools listed in the README |
-| Calendar mutation | Disabled | `M3MCP_ENABLE_CALENDAR_MUTATIONS=1` | `calendar_create_event`, `calendar_update_event`, `calendar_delete_event`, `calendar_create_calendar`, `calendar_delete_calendar` |
+| Calendar mutation | Disabled | `M3MCP_ENABLE_CALENDAR_MUTATIONS=1` | `calendar_create_event`, `calendar_update_event`, `calendar_delete_event`, `calendar_create_calendar`, `calendar_delete_calendar`, `calendar_undo_write` |
 | Permission UI | Disabled | `M3MCP_ENABLE_PERMISSION_UI=1` | `permissions_request`, `permissions_open_settings` |
 | User-created Shortcuts | Disabled | `M3MCP_ENABLE_USER_SHORTCUTS=1` | `ai_writing_tools`, `ai_translate` |
 
@@ -72,6 +72,36 @@ Every enabled Calendar mutation and user-Shortcut invocation requires a separate
 Approval applies only to the waiting call. There is no reusable approval token. The default button is Deny, and a denial, closed sheet, cancelled task, 30-second timeout, or missing usable app window rejects the call. Environment opt-in is availability, not consent.
 
 Cancellation before approval is consumed prevents dispatch. After approval, MCP cancellation and a disconnected local HTTP client are propagated to the in-flight app task and cooperative subprocess work. This is best-effort interruption, **not transactional rollback**. EventKit data committed before cancellation remains committed, and a Shortcut can retain file, network, message, or other effects completed before its process was stopped. A caller must inspect real state before retrying; automatic retry can duplicate a Calendar event or repeat a Shortcut effect.
+
+### Preview and undo for calendar writes
+
+Approval and preview are different questions, and they are asked separately.
+
+`dry_run: true` on any calendar write tool resolves the target, validates the arguments, reports the
+change that would be made with `meta.dry_run = "true"`, and writes nothing. No approval sheet is
+shown for such a call, because nothing is being approved. The exemption is narrow: it is reachable
+only through the literal boolean `true`, only for a tool whose reviewed argument policy declares
+`dry_run`, and only inside a mutation group that was enabled at launch. It is resolved once, by
+`M3MCPWriteIntent`, and the same value decides both the missing sheet and the missing write, so the
+two cannot come apart. A preview discloses nothing the default-safe Calendar read tools do not.
+
+`calendar_create_event`, `calendar_update_event`, and `calendar_delete_event` record what they
+replaced before they commit, and return `meta.undo_token`. `calendar_undo_write` spends it once. The
+journal is in memory, bounded to the 20 most recent writes, and expires each entry 30 minutes after
+its write: snapshots hold event titles, notes, and locations, and persisting them would create a
+second copy of calendar content outside the calendar with its own lifetime and its own exposure.
+
+The boundary of the mechanism, stated rather than implied:
+
+- A rebuilt event has a new `eventIdentifier`. `meta.undo_restores_identifier` reports this.
+- Recurring events and `span: "future_events"` receive no token. The write proceeds and the response
+  carries `meta.undo_unavailable` with the reason.
+- Only fields these tools can write are restored: title, all-day flag, start, end, location, URL,
+  notes, relative alarms, and calendar membership.
+- `calendar_create_calendar` and `calendar_delete_calendar` support `dry_run` but issue no token.
+- Undo is itself a calendar mutation: same launch opt-in, same per-call sheet. It writes the
+  recorded previous values over the current state without checking whether something else changed
+  the event in between. A failed undo changes nothing and leaves the token valid.
 
 Permission UI does not use this additional sheet because macOS owns the permission prompt or System Settings surface. The group is still disabled by default so an MCP caller cannot make the app activate or raise security UI without a launch-time choice.
 Cancelling a permission sequence returns control to AppleMCP, ignores late framework callbacks, and suppresses every later prompt in that sequence. A macOS permission prompt that the framework already displayed is system-owned and may remain on screen until the user dismisses it.

--- a/script/check_release_artifact.sh
+++ b/script/check_release_artifact.sh
@@ -82,6 +82,7 @@ calendar_update_event
 calendar_delete_event
 calendar_create_calendar
 calendar_delete_calendar
+calendar_undo_write
 ai_writing_tools
 ai_translate
 EOF


### PR DESCRIPTION
Kalenderschreibvorgaenge waren bisher endgueltig. Wer wissen wollte, was ein Aufruf anrichtet, musste ihn geschehen lassen und das Ergebnis zurueckelesen: die Zustimmungsflaeche zeigte die Argumente, nicht die Wirkung. Sie konnte nicht sagen, auf welchen Kalender ein Titel faellt, was ein weggelassenes `end` wird oder welchen Termin eine Kennung wirklich meint. Und ein bestaetigter Fehlgriff blieb.

Diese Aenderung gibt beiden Fragen eine Antwort.

## Vorschau

Jedes schreibende Kalenderwerkzeug nimmt jetzt `dry_run`. Mit `dry_run: true` loest das Werkzeug dieselben Argumente auf, prueft dasselbe, benennt dasselbe Ziel, setzt `meta.dry_run = "true"` und hoert dann auf. Es schreibt nichts und zeigt keine Zustimmungsflaeche, weil es nichts gibt, dem zuzustimmen waere. Der Startschalter gilt weiter: ohne Opt-in existiert das Werkzeug nicht, auch nicht fuer eine Vorschau.

Voreinstellung bleibt `commit`. Fehlend, `false` oder ein anderer Typ verhaelt sich wie bisher, damit kein bestehender Aufrufer stillschweigend zur Attrappe wird. Nur das echte `true` waehlt die Vorschau, jede andere Form weist die Argumentpruefung vorher ab.

## Ruecknahme

`calendar_create_event`, `calendar_update_event` und `calendar_delete_event` nehmen vor dem Schreiben einen Abzug und liefern danach `meta.undo_token`. `calendar_undo_write` loest ihn ein: ein angelegter Termin wird geloescht, ein geaenderter Feld fuer Feld auf die vorherigen Werte gesetzt, ein geloeschter aus dem Abzug neu gebaut. Der Token wird genau einmal ausgegeben, laeuft nach 30 Minuten ab und kommt bei einem gescheiterten Versuch zurueck, bei einem abgelaufenen nicht.

## Was die Ruecknahme nicht kann

Steht so auch im README, nicht nur hier:

- Ein neu gebauter geloeschter Termin bekommt eine neue Kennung. `meta.undo_restores_identifier` sagt das vorher.
- Wiederholungsserien und kuenftige Vorkommen bekommen gar keinen Token. Der Abzug beschreibt ein Vorkommen, nicht die Regel dahinter. Der Schreibvorgang findet trotzdem statt, die Antwort traegt dann `meta.undo_unavailable`.
- Kalender anlegen und loeschen kennt die Vorschau, aber keinen Token. Ein geloeschter Kalender nimmt jeden Termin darin mit, und das ist nicht umkehrbar.
- Die Ruecknahme ist selbst ein Schreibvorgang, mit eigenem Opt-in und eigener Zustimmungsflaeche. Die Flaeche zeigt, wofuer der Token steht, nicht den Token.

## Nachgeprueft

370 Tests, 0 Fehler. Zwei absichtliche Fehler eingebaut und beide gefangen: das Zuruecksetzen des Ortes ausgehaengt, waehrend es weiter als erledigt gemeldet wird, bricht `testAnUpdateIsReversedFieldByFieldAndLeavesUntouchedFieldsAlone`; `dry_run` ignorieren lassen bricht `testADryRunIsNotStoppedByTheMissingApprovalUI` fuer alle fuenf Werkzeuge. Alle acht Schreibstellen am `EKEventStore` liegen hinter einer Vorschau-Schranke, nachgezaehlt statt geglaubt.

Vier Tests bleiben ausgeschaltet: der echte Umlauf gegen die Kalenderdatenbank der Maschine. Sie legen sich einen eigenen lokalen Kalender an, arbeiten im Jahr 2031 und raeumen ihn wieder ab, aber sie schreiben in eine echte Datenbank und sollen niemandem durch ein blosses `swift test` passieren. Sie fordern auch keine Berechtigung an, sondern lesen den Status und ueberspringen sich sonst selbst, damit kein Laeufer an einer TCC-Abfrage haengen bleibt. Auf dieser Maschine ist der Kalenderzugriff fuer das Terminal verweigert, der Umlauf ist hier also nicht gelaufen. Wer ihn sehen will:

```
M3MCP_CALENDAR_UNDO_LIVE=1 swift test --filter CalendarUndoLiveTests
```

Die zwei neuen deterministischen Klassen laufen ab jetzt im ThreadSanitizer-Durchgang der CI mit.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL7UoPomBp2Luhg89R6fYk
